### PR TITLE
Implement the MaxDepth option

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -58,7 +58,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNull(deserialized.lastName);
             Assert.IsNotNull(deserialized.department);
             Assert.IsNull(deserialized.birthDate);
-            Assert.IsNotNull(deserialized.car);
         }
 
         [TestMethod]
@@ -135,11 +134,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             
             var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 2, IncludeFields = true});
             var deserialized = serializer.Deserialize<Teacher>(stream);
-
-            Assert.IsNotNull(deserialized.car);
-            Assert.IsNull(deserialized.car.Make);
-            Assert.IsNull(deserialized.car.Model);
-            Assert.IsNull(deserialized.car.Engine);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -132,14 +132,11 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             var stream = new IonSerializer().Serialize(TestObjects.UnitedStates);
             
-            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 5});
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 4});
             var deserialized = serializer.Deserialize<Country>(stream);
-            
-            Assert.IsNotNull(deserialized.States);
-            Assert.IsNotNull(deserialized.States[0].Capital);
+
             Assert.IsNotNull(deserialized.States[0].Capital.Mayor);
-            Assert.IsNotNull(deserialized.States[0].Capital.Mayor.Party);
-            Assert.IsNull(deserialized.States[0].Capital.Mayor.Party.Name);
+            Assert.IsNull(deserialized.States[0].Capital.Mayor.FirstName);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Amazon.IonDotnet.Tree;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -133,7 +132,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             var stream = new IonSerializer(new IonSerializationOptions {IncludeFields = true}).Serialize(TestObjects.drKyler);
             
-            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3, IncludeFields = true});
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 2, IncludeFields = true});
             var deserialized = serializer.Deserialize<Teacher>(stream);
 
             Assert.IsNotNull(deserialized.car);

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Amazon.IonDotnet.Tree;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -125,6 +126,22 @@ namespace Amazon.Ion.ObjectMapper.Test
                     }
                 }
             );
+        }
+
+        [TestMethod]
+        public void SerializeMaxDepthException()
+        {
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3});
+            Assert.ThrowsException<NotSupportedException>(() => serializer.Serialize(TestObjects.honda));
+        }
+        
+        [TestMethod]
+        public void DeserializeMaxDepthException()
+        {
+            var stream = new IonSerializer().Serialize(TestObjects.honda);
+            
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3});
+            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Car>(stream));
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -58,6 +58,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNull(deserialized.lastName);
             Assert.IsNotNull(deserialized.department);
             Assert.IsNull(deserialized.birthDate);
+            Assert.IsNotNull(deserialized.car);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -129,19 +129,17 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
-        public void SerializeMaxDepthException()
+        public void DeserializeMaxDepth()
         {
-            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3});
-            Assert.ThrowsException<NotSupportedException>(() => serializer.Serialize(TestObjects.honda));
-        }
-        
-        [TestMethod]
-        public void DeserializeMaxDepthException()
-        {
-            var stream = new IonSerializer().Serialize(TestObjects.honda);
+            var stream = new IonSerializer(new IonSerializationOptions {IncludeFields = true}).Serialize(TestObjects.drKyler);
             
-            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3});
-            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Car>(stream));
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 3, IncludeFields = true});
+            var deserialized = serializer.Deserialize<Teacher>(stream);
+
+            Assert.IsNotNull(deserialized.car);
+            Assert.IsNull(deserialized.car.Make);
+            Assert.IsNull(deserialized.car.Model);
+            Assert.IsNull(deserialized.car.Engine);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -128,12 +128,18 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
-        public void DeserializeMaxDepth()
+        public void DeserializesObjectsThatExceedMaxDepth()
         {
-            var stream = new IonSerializer(new IonSerializationOptions {IncludeFields = true}).Serialize(TestObjects.drKyler);
+            var stream = new IonSerializer().Serialize(TestObjects.UnitedStates);
             
-            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 2, IncludeFields = true});
-            var deserialized = serializer.Deserialize<Teacher>(stream);
+            var serializer = new IonSerializer(new IonSerializationOptions {MaxDepth = 5});
+            var deserialized = serializer.Deserialize<Country>(stream);
+            
+            Assert.IsNotNull(deserialized.States);
+            Assert.IsNotNull(deserialized.States[0].Capital);
+            Assert.IsNotNull(deserialized.States[0].Capital.Mayor);
+            Assert.IsNotNull(deserialized.States[0].Capital.Mayor.Party);
+            Assert.IsNull(deserialized.States[0].Capital.Mayor.Party.Name);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -151,25 +151,23 @@ namespace Amazon.Ion.ObjectMapper.Test
         private static Teacher[] faculty = { drKyler, drFord };
         public static School fieldAcademy = new School("1234 Fictional Ave", 150, new List<Teacher>(faculty));
 
-        public static PoliticalParty democrats = new PoliticalParty { Name = "Democratic Party" };
-        public static PoliticalParty republicans = new PoliticalParty { Name = "Republican Party" };
-        public static Politician JoeBiden = new Politician {FirstName = "Joe", LastName = "Biden", Party = democrats };
-        public static Politician MurielBowser = new Politician {FirstName = "Muriel", LastName = "Bowser", Party = democrats };
-        public static Politician CherylSelby = new Politician {FirstName = "Cheryl", LastName = "Selby", Party = democrats };
-        public static Politician JayInslee = new Politician {FirstName = "Jay", LastName = "Inslee", Party = democrats };
-        public static Politician SteveAdler = new Politician {FirstName = "Steve", LastName = "Adler", Party = democrats };
-        public static Politician GregAbbott = new Politician {FirstName = "Greg", LastName = "Abbott", Party = republicans };
-        public static City WashingtonDC = new City {Name = "Washington D.C.", Mayor = MurielBowser};
-        public static City Olympia = new City {Name = "Olympia", Mayor = CherylSelby};
-        public static City Austin = new City {Name = "Austin", Mayor = SteveAdler};
-        public static State Washington = new State {Name = "Washington", Capital = Olympia, Governor = JayInslee};
-        public static State Texas = new State {Name = "Texas", Capital = Austin, Governor = GregAbbott};
+        private static Politician GeorgeAdams = new Politician {FirstName = "George", LastName = "Adams" };
+        private static Politician SuzanneBenson = new Politician {FirstName = "Suzanne", LastName = "Benson" };
+        private static Politician SarahCasey = new Politician {FirstName = "Sarah", LastName = "Casey" };
+        private static Politician CharlesRogers = new Politician {FirstName = "Charles", LastName = "Rogers" };
+        private static Politician RolandCohen = new Politician {FirstName = "Roland", LastName = "Cohen" };
+        private static Politician GeneHouston = new Politician {FirstName = "Gene", LastName = "Houston" };
+        private static City WashingtonDC = new City {Name = "Washington D.C.", Mayor = SuzanneBenson};
+        private static City Olympia = new City {Name = "Olympia", Mayor = SarahCasey};
+        private static City Austin = new City {Name = "Austin", Mayor = RolandCohen};
+        private static State Washington = new State {Name = "Washington", Capital = Olympia, Governor = CharlesRogers};
+        private static State Texas = new State {Name = "Texas", Capital = Austin, Governor = GeneHouston};
         private static State[] states = { Washington, Texas };
         public static Country UnitedStates = new Country
         {
             Name = "United States of America",
             Capital = WashingtonDC,
-            President = JoeBiden,
+            President = GeorgeAdams,
             States = new List<State>(states)
         };
 
@@ -368,11 +366,5 @@ namespace Amazon.Ion.ObjectMapper.Test
     {
         public string FirstName { get; init; }
         public string LastName { get; init; }
-        public PoliticalParty Party { get; init; }
-    }
-
-    public class PoliticalParty
-    {
-        public string Name { get; init; }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -307,7 +307,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             this.birthDate = null;
         }
         
-        public Teacher(string firstName, string lastName, string department, DateTime birthDate, Car car)
+        public Teacher(string firstName, string lastName, string department, DateTime birthDate)
         {
             this.firstName = firstName;
             this.lastName = lastName;

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -298,7 +298,6 @@ namespace Amazon.Ion.ObjectMapper.Test
         public readonly string lastName;
         public string department;
         public readonly DateTime? birthDate;
-        public Car car;
 
         public Teacher()
         {
@@ -306,7 +305,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             this.lastName = null;
             this.department = null;
             this.birthDate = null;
-            this.car = null;
         }
         
         public Teacher(string firstName, string lastName, string department, DateTime birthDate, Car car)
@@ -315,13 +313,11 @@ namespace Amazon.Ion.ObjectMapper.Test
             this.lastName = lastName;
             this.department = department;
             this.birthDate = birthDate;
-            this.car = car;
         }
         
         public override string ToString()
         {
-            return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + 
-                   ", birthDate: " + birthDate + ", car:  " + car + " }";
+            return $"<Teacher>{{ firstName: {firstName}, lastName: {lastName}, department: {department}, birthDate: {birthDate} }}";
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -337,7 +337,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public override string ToString()
         {
-            return $"<Teacher>{{ firstName: {firstName}, lastName: {lastName}, department: {department}, birthDate: {birthDate} }}";
+            return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + ", birthDate: " + birthDate + " }";
         }
     }
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -151,6 +151,28 @@ namespace Amazon.Ion.ObjectMapper.Test
         private static Teacher[] faculty = { drKyler, drFord };
         public static School fieldAcademy = new School("1234 Fictional Ave", 150, new List<Teacher>(faculty));
 
+        public static PoliticalParty democrats = new PoliticalParty { Name = "Democratic Party" };
+        public static PoliticalParty republicans = new PoliticalParty { Name = "Republican Party" };
+        public static Politician JoeBiden = new Politician {FirstName = "Joe", LastName = "Biden", Party = democrats };
+        public static Politician MurielBowser = new Politician {FirstName = "Muriel", LastName = "Bowser", Party = democrats };
+        public static Politician CherylSelby = new Politician {FirstName = "Cheryl", LastName = "Selby", Party = democrats };
+        public static Politician JayInslee = new Politician {FirstName = "Jay", LastName = "Inslee", Party = democrats };
+        public static Politician SteveAdler = new Politician {FirstName = "Steve", LastName = "Adler", Party = democrats };
+        public static Politician GregAbbott = new Politician {FirstName = "Greg", LastName = "Abbott", Party = republicans };
+        public static City WashingtonDC = new City {Name = "Washington D.C.", Mayor = MurielBowser};
+        public static City Olympia = new City {Name = "Olympia", Mayor = CherylSelby};
+        public static City Austin = new City {Name = "Austin", Mayor = SteveAdler};
+        public static State Washington = new State {Name = "Washington", Capital = Olympia, Governor = JayInslee};
+        public static State Texas = new State {Name = "Texas", Capital = Austin, Governor = GregAbbott};
+        private static State[] states = { Washington, Texas };
+        public static Country UnitedStates = new Country
+        {
+            Name = "United States of America",
+            Capital = WashingtonDC,
+            President = JoeBiden,
+            States = new List<State>(states)
+        };
+
         public static Ship Titanic = new Ship
         {
             Name = "Titanic",
@@ -319,5 +341,38 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             return $"<Teacher>{{ firstName: {firstName}, lastName: {lastName}, department: {department}, birthDate: {birthDate} }}";
         }
+    }
+
+    public class Country
+    {
+        public string Name { get; init; }
+        public City Capital { get; init; }
+        public Politician President { get; init; }
+        public List<State> States { get; init; }
+    }
+
+    public class State
+    {
+        public string Name { get; init; }
+        public City Capital { get; init; }
+        public Politician Governor { get; init; }
+    }
+
+    public class City
+    {
+        public string Name { get; init; }
+        public Politician Mayor { get; init; }
+    }
+
+    public class Politician
+    {
+        public string FirstName { get; init; }
+        public string LastName { get; init; }
+        public PoliticalParty Party { get; init; }
+    }
+
+    public class PoliticalParty
+    {
+        public string Name { get; init; }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -298,6 +298,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         public readonly string lastName;
         public string department;
         public readonly DateTime? birthDate;
+        public Car car;
 
         public Teacher()
         {
@@ -305,19 +306,22 @@ namespace Amazon.Ion.ObjectMapper.Test
             this.lastName = null;
             this.department = null;
             this.birthDate = null;
+            this.car = null;
         }
         
-        public Teacher(string firstName, string lastName, string department, DateTime birthDate)
+        public Teacher(string firstName, string lastName, string department, DateTime birthDate, Car car)
         {
             this.firstName = firstName;
             this.lastName = lastName;
             this.department = department;
             this.birthDate = birthDate;
+            this.car = car;
         }
         
         public override string ToString()
         {
-            return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + ", birthDate: " + birthDate + " }";
+            return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + 
+                   ", birthDate: " + birthDate + ", car:  " + car + " }";
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -168,12 +168,13 @@ namespace Amazon.Ion.ObjectMapper
 
         public void Serialize<T>(IIonWriter writer, T item)
         {
-            if (currentDepth + 1 >= options.MaxDepth)
+            currentDepth++;
+            if (currentDepth >= options.MaxDepth)
             {
+                currentDepth = 0;
                 throw new NotSupportedException($"Can not serialize further as max object tree depth {options.MaxDepth} is reached");
             }
-            currentDepth++;
-            
+
             if (item == null)
             {
                 new IonNullSerializer().Serialize(writer, (object)null);
@@ -274,11 +275,12 @@ namespace Amazon.Ion.ObjectMapper
 
         public object Deserialize(IIonReader reader, Type type, IonType ionType)
         {
-            if (currentDepth + 1 >= options.MaxDepth)
+            currentDepth++;
+            if (currentDepth >= options.MaxDepth)
             {
+                currentDepth = 0;
                 throw new NotSupportedException($"Can not deserialize further as max object tree depth {options.MaxDepth} is reached");
             }
-            currentDepth++;
 
             object deserialized;
             switch (ionType)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -330,7 +330,7 @@ namespace Amazon.Ion.ObjectMapper
                     case IonType.Struct:
                         return new IonObjectSerializer(this, options, type).Deserialize(reader);
                     default:
-                        throw new NotSupportedException($"Don't know how to Deserialize this Ion data. Last IonType was: {ionType}");
+                        throw new NotSupportedException($"{ionType} is not supported for deserialization");
                 }
             }
             finally

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -136,7 +136,7 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonSerializer
     {
-        internal readonly IonSerializationOptions options;
+        private readonly IonSerializationOptions options;
 
         public IonSerializer() : this(new IonSerializationOptions())
         {

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -168,81 +168,69 @@ namespace Amazon.Ion.ObjectMapper
 
         public void Serialize<T>(IIonWriter writer, T item)
         {
-            try
+            if (item == null)
             {
-                if (++currentDepth >= options.MaxDepth)
-                {
-                    throw new NotSupportedException($"Cannot serialize further as max object tree depth {options.MaxDepth} is reached");
-                }
-
-                if (item == null)
-                {
-                    new IonNullSerializer().Serialize(writer, (object)null);
-                }
-                else if (item is bool)
-                {
-                    new IonBooleanSerializer().Serialize(writer, Convert.ToBoolean(item));
-                }
-                else if (item is int)
-                {
-                    new IonIntSerializer().Serialize(writer, Convert.ToInt32(item));
-                }
-                else if (item is long)
-                {
-                    new IonLongSerializer().Serialize(writer, Convert.ToInt64(item));
-                }
-                else if (item is float)
-                {
-                    new IonFloatSerializer().Serialize(writer, Convert.ToSingle(item));
-                }
-                else if (item is double)
-                {
-                    new IonDoubleSerializer().Serialize(writer, Convert.ToDouble(item));
-                }
-                else if (item is decimal)
-                {
-                    new IonDecimalSerializer().Serialize(writer, Convert.ToDecimal(item));
-                }
-                else if (item is BigDecimal)
-                {
-                    new IonBigDecimalSerializer().Serialize(writer, (BigDecimal)(object)item);
-                }
-                else if (item is byte[])
-                {
-                    new IonByteArraySerializer().Serialize(writer, (byte[])(object)item);
-                }
-                else if (item is string)
-                {
-                    new IonStringSerializer().Serialize(writer, item as string);
-                }
-                else if (item is SymbolToken)
-                {
-                    new IonSymbolSerializer().Serialize(writer, (SymbolToken)(object)item);
-                }
-                else if (item is DateTime)
-                {
-                    new IonDateTimeSerializer().Serialize(writer, (DateTime)(object)item);
-                }
-                else if (item is System.Collections.IList) 
-                {
-                    NewIonListSerializer(item.GetType()).Serialize(writer, (System.Collections.IList)(object)item);
-                }
-                else if (item is Guid) 
-                {
-                    new IonGuidSerializer(options).Serialize(writer, (Guid)(object)item);
-                }
-                else if (item is object) 
-                {
-                    new IonObjectSerializer(this, options, item.GetType()).Serialize(writer, item);
-                }
-                else
-                {
-                    throw new NotSupportedException($"{typeof(T)} is not supported for serialization");
-                }
+                new IonNullSerializer().Serialize(writer, (object)null);
             }
-            finally
+            else if (item is bool)
             {
-                currentDepth--;
+                new IonBooleanSerializer().Serialize(writer, Convert.ToBoolean(item));
+            }
+            else if (item is int)
+            {
+                new IonIntSerializer().Serialize(writer, Convert.ToInt32(item));
+            }
+            else if (item is long)
+            {
+                new IonLongSerializer().Serialize(writer, Convert.ToInt64(item));
+            }
+            else if (item is float)
+            {
+                new IonFloatSerializer().Serialize(writer, Convert.ToSingle(item));
+            }
+            else if (item is double)
+            {
+                new IonDoubleSerializer().Serialize(writer, Convert.ToDouble(item));
+            }
+            else if (item is decimal)
+            {
+                new IonDecimalSerializer().Serialize(writer, Convert.ToDecimal(item));
+            }
+            else if (item is BigDecimal)
+            {
+                new IonBigDecimalSerializer().Serialize(writer, (BigDecimal)(object)item);
+            }
+            else if (item is byte[])
+            {
+                new IonByteArraySerializer().Serialize(writer, (byte[])(object)item);
+            }
+            else if (item is string)
+            {
+                new IonStringSerializer().Serialize(writer, item as string);
+            }
+            else if (item is SymbolToken)
+            {
+                new IonSymbolSerializer().Serialize(writer, (SymbolToken)(object)item);
+            }
+            else if (item is DateTime)
+            {
+                new IonDateTimeSerializer().Serialize(writer, (DateTime)(object)item);
+            }
+            else if (item is System.Collections.IList) 
+            {
+                NewIonListSerializer(item.GetType()).Serialize(writer, (System.Collections.IList)(object)item);
+            }
+            else if (item is Guid) 
+            {
+                new IonGuidSerializer(options).Serialize(writer, (Guid)(object)item);
+            }
+            else if (item is object) 
+            {
+                new IonObjectSerializer(this, options, item.GetType()).Serialize(writer, item);
+            }
+            else
+            {
+                throw new NotSupportedException($"{typeof(T)} is not supported for serialization");
             }
         }
 
@@ -282,7 +270,7 @@ namespace Amazon.Ion.ObjectMapper
             {
                 if (++currentDepth >= options.MaxDepth)
                 {
-                    throw new NotSupportedException($"Cannot deserialize further as max object tree depth {options.MaxDepth} is reached");
+                    return null;
                 }
 
                 switch (ionType)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -136,8 +136,7 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonSerializer
     {
-        private readonly IonSerializationOptions options;
-        private int currentDepth;
+        internal readonly IonSerializationOptions options;
 
         public IonSerializer() : this(new IonSerializationOptions())
         {
@@ -147,7 +146,6 @@ namespace Amazon.Ion.ObjectMapper
         public IonSerializer(IonSerializationOptions options)
         {
             this.options = options;
-            this.currentDepth = 0;
         }
 
         public Stream Serialize<T>(T item)
@@ -266,64 +264,57 @@ namespace Amazon.Ion.ObjectMapper
 
         public object Deserialize(IIonReader reader, Type type, IonType ionType)
         {
-            try
+            if (reader.CurrentDepth >= this.options.MaxDepth)
             {
-                if (++currentDepth >= options.MaxDepth)
-                {
-                    return null;
-                }
-
-                switch (ionType)
-                {
-                    case IonType.None:
-                    case IonType.Null:
-                        return new IonNullSerializer().Deserialize(reader);
-                    case IonType.Bool:
-                        return new IonBooleanSerializer().Deserialize(reader);
-                    case IonType.Int:
-                        if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
-                        {
-                            return new IonLongSerializer().Deserialize(reader);
-                        }
-                        return new IonIntSerializer().Deserialize(reader);
-                    case IonType.Float:
-                        if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
-                        {
-                            return new IonFloatSerializer().Deserialize(reader);
-                        }
-                        return new IonDoubleSerializer().Deserialize(reader);
-                    case IonType.Decimal:
-                        if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
-                        {
-                            return new IonDecimalSerializer().Deserialize(reader);
-                        }
-                        return new IonBigDecimalSerializer().Deserialize(reader);
-                    case IonType.String:
-                        return new IonStringSerializer().Deserialize(reader);
-                    case IonType.Symbol:
-                        return new IonSymbolSerializer().Deserialize(reader);
-                    case IonType.Timestamp:
-                        return new IonDateTimeSerializer().Deserialize(reader);
-                    case IonType.Blob:
-                        if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
-                            || type.IsAssignableTo(typeof(Guid)))
-                        {
-                            return new IonGuidSerializer(options).Deserialize(reader);
-                        }
-                        return new IonByteArraySerializer().Deserialize(reader);
-                    case IonType.Clob:
-                        return new IonClobSerializer().Deserialize(reader);
-                    case IonType.List:
-                        return NewIonListSerializer(type).Deserialize(reader);
-                    case IonType.Struct:
-                        return new IonObjectSerializer(this, options, type).Deserialize(reader);
-                    default:
-                        throw new NotSupportedException($"{ionType} is not supported for deserialization");
-                }
+                return null;
             }
-            finally
+
+            switch (ionType)
             {
-                currentDepth--;
+                case IonType.None:
+                case IonType.Null:
+                    return new IonNullSerializer().Deserialize(reader);
+                case IonType.Bool:
+                    return new IonBooleanSerializer().Deserialize(reader);
+                case IonType.Int:
+                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
+                    {
+                        return new IonLongSerializer().Deserialize(reader);
+                    }
+                    return new IonIntSerializer().Deserialize(reader);
+                case IonType.Float:
+                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
+                    {
+                        return new IonFloatSerializer().Deserialize(reader);
+                    }
+                    return new IonDoubleSerializer().Deserialize(reader);
+                case IonType.Decimal:
+                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
+                    {
+                        return new IonDecimalSerializer().Deserialize(reader);
+                    }
+                    return new IonBigDecimalSerializer().Deserialize(reader);
+                case IonType.String:
+                    return new IonStringSerializer().Deserialize(reader);
+                case IonType.Symbol:
+                    return new IonSymbolSerializer().Deserialize(reader);
+                case IonType.Timestamp:
+                    return new IonDateTimeSerializer().Deserialize(reader);
+                case IonType.Blob:
+                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
+                        || type.IsAssignableTo(typeof(Guid)))
+                    {
+                        return new IonGuidSerializer(options).Deserialize(reader);
+                    }
+                    return new IonByteArraySerializer().Deserialize(reader);
+                case IonType.Clob:
+                    return new IonClobSerializer().Deserialize(reader);
+                case IonType.List:
+                    return NewIonListSerializer(type).Deserialize(reader);
+                case IonType.Struct:
+                    return new IonObjectSerializer(this, options, type).Deserialize(reader);
+                default:
+                    throw new NotSupportedException($"{ionType} is not supported for deserialization");
             }
         }
 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -172,7 +172,7 @@ namespace Amazon.Ion.ObjectMapper
             if (currentDepth >= options.MaxDepth)
             {
                 currentDepth = 0;
-                throw new NotSupportedException($"Can not serialize further as max object tree depth {options.MaxDepth} is reached");
+                throw new NotSupportedException($"Cannot serialize further as max object tree depth {options.MaxDepth} is reached");
             }
 
             if (item == null)
@@ -237,7 +237,7 @@ namespace Amazon.Ion.ObjectMapper
             }
             else
             {
-                throw new NotSupportedException("Do not know how to serialize type " + typeof(T));
+                throw new NotSupportedException($"{typeof(T)} is not supported for serialization");
             }
 
             currentDepth--;
@@ -279,7 +279,7 @@ namespace Amazon.Ion.ObjectMapper
             if (currentDepth >= options.MaxDepth)
             {
                 currentDepth = 0;
-                throw new NotSupportedException($"Can not deserialize further as max object tree depth {options.MaxDepth} is reached");
+                throw new NotSupportedException($"Cannot deserialize further as max object tree depth {options.MaxDepth} is reached");
             }
 
             object deserialized;
@@ -352,7 +352,7 @@ namespace Amazon.Ion.ObjectMapper
                     deserialized = new IonObjectSerializer(this, options, type).Deserialize(reader);
                     break;
                 default:
-                    throw new NotSupportedException("Don't know how to Deserialize this Ion data. Last IonType was: " + ionType);
+                    throw new NotSupportedException($"Don't know how to Deserialize this Ion data. Last IonType was: {ionType}");
             }
 
             currentDepth--;

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -171,85 +171,85 @@ namespace Amazon.Ion.ObjectMapper
                 new IonNullSerializer().Serialize(writer, (object)null);
                 return;
             }
-            
+
             if (item is bool)
             {
                 new IonBooleanSerializer().Serialize(writer, Convert.ToBoolean(item));
                 return;
             }
-            
+
             if (item is int)
             {
                 new IonIntSerializer().Serialize(writer, Convert.ToInt32(item));
                 return;
             }
-            
+
             if (item is long)
             {
                 new IonLongSerializer().Serialize(writer, Convert.ToInt64(item));
                 return;
             }
-            
+
             if (item is float)
             {
                 new IonFloatSerializer().Serialize(writer, Convert.ToSingle(item));
                 return;
             }
-            
+
             if (item is double)
             {
                 new IonDoubleSerializer().Serialize(writer, Convert.ToDouble(item));
                 return;
             }
-            
+
             if (item is decimal)
             {
                 new IonDecimalSerializer().Serialize(writer, Convert.ToDecimal(item));
                 return;
             }
-            
+
             if (item is BigDecimal)
             {
                 new IonBigDecimalSerializer().Serialize(writer, (BigDecimal)(object)item);
                 return;
             }
-            
+
             if (item is byte[])
             {
                 new IonByteArraySerializer().Serialize(writer, (byte[])(object)item);
                 return;
             }
-            
+
             if (item is string)
             {
                 new IonStringSerializer().Serialize(writer, item as string);
                 return;
             }
-            
+
             if (item is SymbolToken)
             {
                 new IonSymbolSerializer().Serialize(writer, (SymbolToken)(object)item);
                 return;
             }
-            
+
             if (item is DateTime)
             {
                 new IonDateTimeSerializer().Serialize(writer, (DateTime)(object)item);
                 return;
             }
-            
+
             if (item is System.Collections.IList) 
             {
                 NewIonListSerializer(item.GetType()).Serialize(writer, (System.Collections.IList)(object)item);
                 return;
             }
-            
+
             if (item is Guid) 
             {
                 new IonGuidSerializer(options).Serialize(writer, (Guid)(object)item);
                 return;
             }
-            
+
             if (item is object) 
             {
                 new IonObjectSerializer(this, options, item.GetType()).Serialize(writer, item);

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -296,53 +296,84 @@ namespace Amazon.Ion.ObjectMapper
                 return null;
             }
 
-            switch (ionType)
+            if (ionType == IonType.None || ionType == IonType.Null)
             {
-                case IonType.None:
-                case IonType.Null:
-                    return new IonNullSerializer().Deserialize(reader);
-                case IonType.Bool:
-                    return new IonBooleanSerializer().Deserialize(reader);
-                case IonType.Int:
-                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
-                    {
-                        return new IonLongSerializer().Deserialize(reader);
-                    }
-                    return new IonIntSerializer().Deserialize(reader);
-                case IonType.Float:
-                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
-                    {
-                        return new IonFloatSerializer().Deserialize(reader);
-                    }
-                    return new IonDoubleSerializer().Deserialize(reader);
-                case IonType.Decimal:
-                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
-                    {
-                        return new IonDecimalSerializer().Deserialize(reader);
-                    }
-                    return new IonBigDecimalSerializer().Deserialize(reader);
-                case IonType.String:
-                    return new IonStringSerializer().Deserialize(reader);
-                case IonType.Symbol:
-                    return new IonSymbolSerializer().Deserialize(reader);
-                case IonType.Timestamp:
-                    return new IonDateTimeSerializer().Deserialize(reader);
-                case IonType.Blob:
-                    if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
-                        || type.IsAssignableTo(typeof(Guid)))
-                    {
-                        return new IonGuidSerializer(options).Deserialize(reader);
-                    }
-                    return new IonByteArraySerializer().Deserialize(reader);
-                case IonType.Clob:
-                    return new IonClobSerializer().Deserialize(reader);
-                case IonType.List:
-                    return NewIonListSerializer(type).Deserialize(reader);
-                case IonType.Struct:
-                    return new IonObjectSerializer(this, options, type).Deserialize(reader);
-                default:
-                    throw new NotSupportedException($"{ionType} is not supported for deserialization");
+                return new IonNullSerializer().Deserialize(reader);
             }
+
+            if (ionType == IonType.Bool)
+            {
+                return new IonBooleanSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Int)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
+                {
+                    return new IonLongSerializer().Deserialize(reader);
+                }
+                return new IonIntSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Float)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
+                {
+                    return new IonFloatSerializer().Deserialize(reader);
+                }
+                return new IonDoubleSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Decimal)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
+                {
+                    return new IonDecimalSerializer().Deserialize(reader);
+                }
+                return new IonBigDecimalSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Blob) 
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
+                    || type.IsAssignableTo(typeof(Guid)))
+                {
+                    return new IonGuidSerializer(options).Deserialize(reader);
+                }
+                return new IonByteArraySerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.String) 
+            {
+                return new IonStringSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Symbol) 
+            {
+                return new IonSymbolSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Timestamp) 
+            {
+                return new IonDateTimeSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.Clob) 
+            {
+                return new IonClobSerializer().Deserialize(reader);
+            }
+
+            if (ionType == IonType.List) 
+            {
+                return NewIonListSerializer(type).Deserialize(reader);
+            }
+
+            if (ionType == IonType.Struct) 
+            {
+                return new IonObjectSerializer(this, options, type).Deserialize(reader);
+            }
+
+            throw new NotSupportedException($"Data with Ion type {ionType} is not supported for deserialization");
         }
 
         public T Deserialize<T>(IIonReader reader)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -169,67 +169,94 @@ namespace Amazon.Ion.ObjectMapper
             if (item == null)
             {
                 new IonNullSerializer().Serialize(writer, (object)null);
+                return;
             }
-            else if (item is bool)
+            
+            if (item is bool)
             {
                 new IonBooleanSerializer().Serialize(writer, Convert.ToBoolean(item));
+                return;
             }
-            else if (item is int)
+            
+            if (item is int)
             {
                 new IonIntSerializer().Serialize(writer, Convert.ToInt32(item));
+                return;
             }
-            else if (item is long)
+            
+            if (item is long)
             {
                 new IonLongSerializer().Serialize(writer, Convert.ToInt64(item));
+                return;
             }
-            else if (item is float)
+            
+            if (item is float)
             {
                 new IonFloatSerializer().Serialize(writer, Convert.ToSingle(item));
+                return;
             }
-            else if (item is double)
+            
+            if (item is double)
             {
                 new IonDoubleSerializer().Serialize(writer, Convert.ToDouble(item));
+                return;
             }
-            else if (item is decimal)
+            
+            if (item is decimal)
             {
                 new IonDecimalSerializer().Serialize(writer, Convert.ToDecimal(item));
+                return;
             }
-            else if (item is BigDecimal)
+            
+            if (item is BigDecimal)
             {
                 new IonBigDecimalSerializer().Serialize(writer, (BigDecimal)(object)item);
+                return;
             }
-            else if (item is byte[])
+            
+            if (item is byte[])
             {
                 new IonByteArraySerializer().Serialize(writer, (byte[])(object)item);
+                return;
             }
-            else if (item is string)
+            
+            if (item is string)
             {
                 new IonStringSerializer().Serialize(writer, item as string);
+                return;
             }
-            else if (item is SymbolToken)
+            
+            if (item is SymbolToken)
             {
                 new IonSymbolSerializer().Serialize(writer, (SymbolToken)(object)item);
+                return;
             }
-            else if (item is DateTime)
+            
+            if (item is DateTime)
             {
                 new IonDateTimeSerializer().Serialize(writer, (DateTime)(object)item);
+                return;
             }
-            else if (item is System.Collections.IList) 
+            
+            if (item is System.Collections.IList) 
             {
                 NewIonListSerializer(item.GetType()).Serialize(writer, (System.Collections.IList)(object)item);
+                return;
             }
-            else if (item is Guid) 
+            
+            if (item is Guid) 
             {
                 new IonGuidSerializer(options).Serialize(writer, (Guid)(object)item);
+                return;
             }
-            else if (item is object) 
+            
+            if (item is object) 
             {
                 new IonObjectSerializer(this, options, item.GetType()).Serialize(writer, item);
+                return;
             }
-            else
-            {
-                throw new NotSupportedException($"{typeof(T)} is not supported for serialization");
-            }
+
+            throw new NotSupportedException($"Do not know how to serialize type {typeof(T)}");
         }
 
         private IonListSerializer NewIonListSerializer(Type listType) 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -291,7 +291,7 @@ namespace Amazon.Ion.ObjectMapper
 
         public object Deserialize(IIonReader reader, Type type, IonType ionType)
         {
-            if (reader.CurrentDepth >= this.options.MaxDepth)
+            if (reader.CurrentDepth > this.options.MaxDepth)
             {
                 return null;
             }


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/6.

Implements MaxDepth which determines how far down on object tree to recurse (for the sake of avoiding stack overflow).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
