### PR TITLE
Implement the PropertyNameCaseInsensitive option

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -28,7 +28,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(motorcycle));
 
-            Assert.IsFalse(serialized.ContainsField("brand"));
+            Assert.IsFalse(serialized.ContainsField("Brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -66,7 +66,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {canOffroad = true}));
 
-            Assert.IsFalse(serialized.ContainsField("brand"));
+            Assert.IsFalse(serialized.ContainsField("Brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -90,7 +90,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(TestObjects.harley));
 
-            Assert.IsTrue(serialized.ContainsField("Brand"));
+            Assert.IsTrue(serialized.ContainsField("brand"));
             Assert.IsTrue(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -83,29 +83,32 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNull(deserialized.color);
             Assert.IsNotNull(deserialized.canOffroad);
         }
-        
-        [TestMethod]
-        public void SerializesObjectsWithCaseInsensitiveProperties()
-        {
-            var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
-            IIonStruct serialized = StreamToIonValue(serializer.Serialize(TestObjects.harley));
 
-            Assert.IsTrue(serialized.ContainsField("make"));
-            Assert.IsTrue(serialized.ContainsField("color"));
-            Assert.IsTrue(serialized.ContainsField("canOffroad"));
-        }
-        
         [TestMethod]
-        public void DeserializesObjectsWithCaseInsensitiveProperties()
+        public void SerializesAndDeserializesObjectsWithCaseInsensitiveProperties()
         {
-            var stream = new IonSerializer().Serialize(TestObjects.harley);
+            var serializer = new IonSerializer(new IonSerializationOptions { PropertyNameCaseInsensitive = true });
+            var stream = serializer.Serialize(TestObjects.Harley);
 
-            var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
-            var deserialized = serializer.Deserialize<MOTORCYCLE>(stream);
+            var deserialized1 = serializer.Deserialize<MOTORCYCLE>(stream);
             
-            Assert.AreEqual("Harley", deserialized.MAKE);
-            Assert.IsNull(deserialized.COLOR);
-            Assert.IsFalse(deserialized.CANOFFROAD);
+            Assert.AreEqual(TestObjects.Harley.Make, deserialized1.MAKE);
+            Assert.IsNull(deserialized1.COLOR);
+            Assert.IsFalse(deserialized1.CANOFFROAD);
+
+            stream.Position = 0;
+            var deserialized2 = serializer.Deserialize<motorcycle>(stream);
+            
+            Assert.AreEqual(TestObjects.Harley.Make, deserialized2.make);
+            Assert.IsNotNull(deserialized2.color);
+            Assert.IsFalse(deserialized2.canoffroad);
+            
+            stream.Position = 0;
+            var deserialized3 = serializer.Deserialize<MoToRcYcLe>(stream);
+            
+            Assert.AreEqual(TestObjects.Harley.Make, deserialized3.MaKe);
+            Assert.IsNull(deserialized3.CoLoR);
+            Assert.IsFalse(deserialized3.CaNoFfRoAd);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -88,27 +88,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void SerializesAndDeserializesObjectsWithCaseInsensitiveProperties()
         {
             var serializer = new IonSerializer(new IonSerializationOptions { PropertyNameCaseInsensitive = true });
-            var stream = serializer.Serialize(TestObjects.Harley);
-
-            var deserialized1 = serializer.Deserialize<MOTORCYCLE>(stream);
             
-            Assert.AreEqual(TestObjects.Harley.Make, deserialized1.MAKE);
-            Assert.IsNull(deserialized1.COLOR);
-            Assert.IsFalse(deserialized1.CANOFFROAD);
-
-            stream.Position = 0;
-            var deserialized2 = serializer.Deserialize<motorcycle>(stream);
+            var stream = serializer.Serialize(TestObjects.Titanic);
+            var deserialized = serializer.Deserialize<ShipWithVariedCasing>(stream);
             
-            Assert.AreEqual(TestObjects.Harley.Make, deserialized2.make);
-            Assert.IsNotNull(deserialized2.color);
-            Assert.IsFalse(deserialized2.canoffroad);
-            
-            stream.Position = 0;
-            var deserialized3 = serializer.Deserialize<MoToRcYcLe>(stream);
-            
-            Assert.AreEqual(TestObjects.Harley.Make, deserialized3.MaKe);
-            Assert.IsNull(deserialized3.CoLoR);
-            Assert.IsFalse(deserialized3.CaNoFfRoAd);
+            Assert.AreEqual(TestObjects.Titanic.Name, deserialized.name);
+            Assert.AreEqual(TestObjects.Titanic.Weight, deserialized.WEIGHT);
+            Assert.AreEqual(TestObjects.Titanic.Capacity, deserialized.CaPaCiTy);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -28,7 +28,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(motorcycle));
 
-            Assert.IsFalse(serialized.ContainsField("make"));
+            Assert.IsFalse(serialized.ContainsField("brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -66,7 +66,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {canOffroad = true}));
 
-            Assert.IsFalse(serialized.ContainsField("make"));
+            Assert.IsFalse(serialized.ContainsField("brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -79,7 +79,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             var deserialized = serializer.Deserialize<Motorcycle>(stream);
             
-            Assert.IsNull(deserialized.Make);
+            Assert.IsNull(deserialized.Brand);
             Assert.IsNull(deserialized.color);
             Assert.IsNotNull(deserialized.canOffroad);
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -88,7 +88,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void SerializesObjectsWithCaseInsensitiveProperties()
         {
             var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
-            IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true}));
+            IIonStruct serialized = StreamToIonValue(serializer.Serialize(TestObjects.harley));
 
             Assert.IsTrue(serialized.ContainsField("Brand"));
             Assert.IsTrue(serialized.ContainsField("color"));
@@ -98,7 +98,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializesObjectsWithCaseInsensitiveProperties()
         {
-            var stream = new IonSerializer().Serialize(new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true});
+            var stream = new IonSerializer().Serialize(TestObjects.harley);
 
             var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
             var deserialized = serializer.Deserialize<MOTORCYCLE>(stream);

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -28,7 +28,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(motorcycle));
 
-            Assert.IsFalse(serialized.ContainsField("brand"));
+            Assert.IsFalse(serialized.ContainsField("make"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -66,7 +66,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {canOffroad = true}));
 
-            Assert.IsFalse(serialized.ContainsField("brand"));
+            Assert.IsFalse(serialized.ContainsField("make"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -79,7 +79,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             var deserialized = serializer.Deserialize<Motorcycle>(stream);
             
-            Assert.IsNull(deserialized.Brand);
+            Assert.IsNull(deserialized.Make);
             Assert.IsNull(deserialized.color);
             Assert.IsNotNull(deserialized.canOffroad);
         }
@@ -90,7 +90,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(TestObjects.harley));
 
-            Assert.IsTrue(serialized.ContainsField("brand"));
+            Assert.IsTrue(serialized.ContainsField("make"));
             Assert.IsTrue(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -103,7 +103,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
             var deserialized = serializer.Deserialize<MOTORCYCLE>(stream);
             
-            Assert.AreEqual("Harley", deserialized.BRAND);
+            Assert.AreEqual("Harley", deserialized.MAKE);
             Assert.IsNull(deserialized.COLOR);
             Assert.IsFalse(deserialized.CANOFFROAD);
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -28,7 +28,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(motorcycle));
 
-            Assert.IsFalse(serialized.ContainsField("Brand"));
+            Assert.IsFalse(serialized.ContainsField("brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -66,7 +66,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
             IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {canOffroad = true}));
 
-            Assert.IsFalse(serialized.ContainsField("Brand"));
+            Assert.IsFalse(serialized.ContainsField("brand"));
             Assert.IsFalse(serialized.ContainsField("color"));
             Assert.IsTrue(serialized.ContainsField("canOffroad"));
         }
@@ -82,6 +82,30 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNull(deserialized.Brand);
             Assert.IsNull(deserialized.color);
             Assert.IsNotNull(deserialized.canOffroad);
+        }
+        
+        [TestMethod]
+        public void SerializesObjectsWithCaseInsensitiveProperties()
+        {
+            var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
+            IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true}));
+
+            Assert.IsTrue(serialized.ContainsField("Brand"));
+            Assert.IsTrue(serialized.ContainsField("color"));
+            Assert.IsTrue(serialized.ContainsField("canOffroad"));
+        }
+        
+        [TestMethod]
+        public void DeserializesObjectsWithCaseInsensitiveProperties()
+        {
+            var stream = new IonSerializer().Serialize(new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true});
+
+            var serializer = new IonSerializer(new IonSerializationOptions {PropertyNameCaseInsensitive = true});
+            var deserialized = serializer.Deserialize<MOTORCYCLE>(stream);
+            
+            Assert.AreEqual("Harley", deserialized.BRAND);
+            Assert.IsNull(deserialized.COLOR);
+            Assert.IsFalse(deserialized.CANOFFROAD);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -55,8 +55,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string color;
 
         [IonField]
-        public bool canOffroad; 
-
+        public bool canOffroad;
+        
         public override string ToString()
         {
             return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -52,7 +52,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string Brand { get; init; }
 
         [IonField]
-        public string color;
+        public string color; 
 
         [IonField]
         public bool canOffroad;

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -52,10 +52,10 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string Brand { get; init; }
 
         [IonField]
-        public string color; 
+        public string color;
 
         [IonField]
-        public bool canOffroad;
+        public bool canOffroad; 
         
         public override string ToString()
         {

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -63,63 +63,38 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
-    // For testing case insensitive deserialization.
-    public class MOTORCYCLE : Vehicle
-    {
-        public string MAKE { get; init; }
-
-        [IonField]
-        public string COLOR;
-
-        [IonField]
-        public bool CANOFFROAD;
-        
-        public override string ToString()
-        {
-            return $"<MOTORCYCLE>{{ MAKE: {this.MAKE}, COLOR: {this.COLOR}, CANOFFROAD: {this.CANOFFROAD} }}";
-        }
-    }
-    
-    // For testing case insensitive deserialization.
-    public class motorcycle : Vehicle
-    {
-        public string make { get; init; }
-
-        [IonField]
-        public string color;
-
-        [IonField]
-        public bool canoffroad;
-        
-        public override string ToString()
-        {
-            return $"<motorcycle>{{ make: {this.make}, color: {this.color}, canoffroad: {this.canoffroad} }}";
-        }
-    }
-    
-    // For testing case insensitive deserialization.
-    public class MoToRcYcLe : Vehicle
-    {
-        public string MaKe { get; init; }
-
-        [IonField]
-        public string CoLoR;
-
-        [IonField]
-        public bool CaNoFfRoAd;
-        
-        public override string ToString()
-        {
-            return $"<MoToRcYcLe>{{ MaKe: {this.MaKe}, CoLoR: {this.CoLoR}, CaNoFfRoAd: {this.CaNoFfRoAd} }}";
-        }
-    }
-    
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Yacht : Boat
     {
         public override string ToString()
         {
             return "<Yacht>";
+        }
+    }
+
+    [IonDoNotAnnotateType(ExcludeDescendants = true)]
+    public class Ship : Boat
+    {
+        public string Name { get; init; }
+        public int Weight { get; init; }
+        public int Capacity { get; init; }
+        
+        public override string ToString()
+        {
+            return $"<Ship>{{ Name: {this.Name}, Weight: {this.Weight}, Capacity: {this.Capacity} }}";
+        }
+    }
+    
+    // For testing case insensitive deserialization.
+    public class ShipWithVariedCasing : Boat
+    {
+        public string name { get; init; }
+        public double WEIGHT { get; init; }
+        public int CaPaCiTy { get; init; }
+        
+        public override string ToString()
+        {
+            return $"<Ship>{{ name: {this.name}, WEIGHT: {this.WEIGHT}, CaPaCiTy: {this.CaPaCiTy} }}";
         }
     }
     
@@ -166,13 +141,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
-        public static readonly Motorcycle Harley = new Motorcycle
-        {
-            Make = "Harley",
-            color = "Black",
-            canOffroad = true,
-        };
-
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 
         public static Radio fmRadio = new Radio { Band = "FM" };
@@ -181,6 +149,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         public static Teacher drFord = new Teacher("Rachel", "Ford", "Chemistry", DateTime.Parse("04/29/1985"));
         private static Teacher[] faculty = { drKyler, drFord };
         public static School fieldAcademy = new School("1234 Fictional Ave", 150, new List<Teacher>(faculty));
+
+        public static Ship Titanic = new Ship
+        {
+            Name = "Titanic",
+            Weight = 52310,
+            Capacity = 2230,
+        };
     }
 
     public class Car

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -49,7 +49,7 @@ namespace Amazon.Ion.ObjectMapper.Test
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Motorcycle : Vehicle
     {
-        public string Brand { get; init; }
+        public string Make { get; init; }
 
         [IonField]
         public string color;
@@ -59,13 +59,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public override string ToString()
         {
-            return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";
+            return $"<Motorcycle>{{ Make: {this.Make}, color: {this.color}, canOffroad: {this.canOffroad} }}";
         }
     }
 
     public class MOTORCYCLE : Vehicle
     {
-        public string BRAND { get; init; }
+        public string MAKE { get; init; }
 
         [IonField]
         public string COLOR;
@@ -75,7 +75,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public override string ToString()
         {
-            return "<MOTORCYCLE>{ BRAND: " + BRAND + ", COLOR: " + COLOR + ", CANOFFROAD: " + CANOFFROAD + " }";
+            return $"<MOTORCYCLE>{{ MAKE: {this.MAKE}, COLOR: {this.COLOR}, CANOFFROAD: {this.CANOFFROAD} }}";
         }
     }
     
@@ -131,7 +131,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
-        public static Motorcycle harley = new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true};
+        public static Motorcycle harley = new Motorcycle {Make = "Harley", color = "Black", canOffroad = true};
 
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -131,6 +131,8 @@ namespace Amazon.Ion.ObjectMapper.Test
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
+        public static Motorcycle harley = new Motorcycle {Brand = "Harley", color = "Black", canOffroad = true};
+
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 
         public static Radio fmRadio = new Radio { Band = "FM" };

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -62,6 +62,22 @@ namespace Amazon.Ion.ObjectMapper.Test
             return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";
         }
     }
+
+    public class MOTORCYCLE : Vehicle
+    {
+        public string BRAND { get; init; }
+
+        [IonField]
+        public string COLOR;
+
+        [IonField]
+        public bool CANOFFROAD; 
+        
+        public override string ToString()
+        {
+            return "<MOTORCYCLE>{ BRAND: " + BRAND + ", COLOR: " + COLOR + ", CANOFFROAD: " + CANOFFROAD + " }";
+        }
+    }
     
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Yacht : Boat

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -55,7 +55,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string color;
 
         [IonField]
-        public bool canOffroad; 
+        public bool canOffroad;
         
         public override string ToString()
         {
@@ -63,6 +63,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
+    // For testing case insensitive deserialization.
     public class MOTORCYCLE : Vehicle
     {
         public string MAKE { get; init; }
@@ -71,11 +72,45 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string COLOR;
 
         [IonField]
-        public bool CANOFFROAD; 
+        public bool CANOFFROAD;
         
         public override string ToString()
         {
             return $"<MOTORCYCLE>{{ MAKE: {this.MAKE}, COLOR: {this.COLOR}, CANOFFROAD: {this.CANOFFROAD} }}";
+        }
+    }
+    
+    // For testing case insensitive deserialization.
+    public class motorcycle : Vehicle
+    {
+        public string make { get; init; }
+
+        [IonField]
+        public string color;
+
+        [IonField]
+        public bool canoffroad;
+        
+        public override string ToString()
+        {
+            return $"<motorcycle>{{ make: {this.make}, color: {this.color}, canoffroad: {this.canoffroad} }}";
+        }
+    }
+    
+    // For testing case insensitive deserialization.
+    public class MoToRcYcLe : Vehicle
+    {
+        public string MaKe { get; init; }
+
+        [IonField]
+        public string CoLoR;
+
+        [IonField]
+        public bool CaNoFfRoAd;
+        
+        public override string ToString()
+        {
+            return $"<MoToRcYcLe>{{ MaKe: {this.MaKe}, CoLoR: {this.CoLoR}, CaNoFfRoAd: {this.CaNoFfRoAd} }}";
         }
     }
     
@@ -131,7 +166,12 @@ namespace Amazon.Ion.ObjectMapper.Test
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
-        public static Motorcycle harley = new Motorcycle {Make = "Harley", color = "Black", canOffroad = true};
+        public static readonly Motorcycle Harley = new Motorcycle
+        {
+            Make = "Harley",
+            color = "Black",
+            canOffroad = true,
+        };
 
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -49,20 +49,20 @@ namespace Amazon.Ion.ObjectMapper.Test
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Motorcycle : Vehicle
     {
-        public string Make { get; init; }
+        public string Brand { get; init; }
 
         [IonField]
         public string color;
 
         [IonField]
-        public bool canOffroad;
-        
+        public bool canOffroad; 
+
         public override string ToString()
         {
-            return $"<Motorcycle>{{ Make: {this.Make}, color: {this.color}, canOffroad: {this.canOffroad} }}";
+            return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";
         }
     }
-
+    
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Yacht : Boat
     {

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -115,6 +115,12 @@ namespace Amazon.Ion.ObjectMapper
             {
                 return ((IonPropertyName)ionPropertyName).Name;
             }
+
+            if (options.PropertyNameCaseInsensitive)
+            {
+                return property.Name;
+            }
+            
             return options.NamingConvention.FromProperty(property.Name);
         }
 
@@ -132,6 +138,11 @@ namespace Amazon.Ion.ObjectMapper
             if (exact != null)
             {
                 return exact;
+            }
+
+            if (options.PropertyNameCaseInsensitive)
+            {
+                return targetType.GetProperties().FirstOrDefault(p => String.Equals(p.Name, readName, StringComparison.CurrentCultureIgnoreCase));
             }
 
             var name = options.NamingConvention.ToProperty(readName);

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -116,11 +116,6 @@ namespace Amazon.Ion.ObjectMapper
                 return ((IonPropertyName)ionPropertyName).Name;
             }
 
-            if (options.PropertyNameCaseInsensitive)
-            {
-                return property.Name;
-            }
-            
             return options.NamingConvention.FromProperty(property.Name);
         }
 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -137,7 +137,7 @@ namespace Amazon.Ion.ObjectMapper
 
             if (options.PropertyNameCaseInsensitive)
             {
-                return targetType.GetProperties().FirstOrDefault(p => String.Equals(p.Name, readName, StringComparison.CurrentCultureIgnoreCase));
+                return targetType.GetProperties().FirstOrDefault(p => String.Equals(p.Name, readName, StringComparison.OrdinalIgnoreCase));
             }
 
             var name = options.NamingConvention.ToProperty(readName);

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -109,7 +109,7 @@ namespace Amazon.Ion.ObjectMapper
         public bool IgnoreNulls { get; init; } = false;
         public bool IgnoreReadOnlyFields { get; init; } = false;
         public readonly bool IgnoreReadOnlyProperties;
-        public readonly bool PropertyNameCaseInsensitive;
+        public bool PropertyNameCaseInsensitive { get; init; } = false;
         public bool IgnoreDefaults { get; init; } = false;
         public bool IncludeTypeInformation { get; init; } = false;
         public TypeAnnotationPrefix TypeAnnotationPrefix { get; init; } = new NamespaceTypeAnnotationPrefix();


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/4

Option to determine whether or not property names are case insensitive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
