### PR TITLE
Implement the IonPropertyGetter & IonPropertySetter attributes

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -110,6 +110,21 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void SerializesAndDeserializesGetterAndSetterMethods()
+        {
+            var serializer = new IonSerializer();
+
+            var stream = serializer.Serialize(TestObjects.honda);
+            IIonStruct serialized = StreamToIonValue(stream);
+            Assert.IsTrue(serialized.ContainsField("color"));
+
+            stream.Position = 0;
+            var deserialized = serializer.Deserialize<Car>(stream);
+            Assert.IsNotNull(deserialized.color);
+            Assert.AreEqual(TestObjects.honda.GetColor(), deserialized.color);
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()
         {
             Check(

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -118,7 +118,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             IIonStruct serialized = StreamToIonValue(stream);
             Assert.IsTrue(serialized.ContainsField("color"));
 
-            stream.Position = 0;
             var deserialized = serializer.Deserialize<Car>(stream);
             Assert.AreEqual(TestObjects.honda.GetColor(), deserialized.color);
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -113,13 +113,18 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void SerializesAndDeserializesGetterAndSetterMethods()
         {
             var serializer = new IonSerializer();
+            var ruler = new Ruler {size = 20};
 
-            var stream = serializer.Serialize(TestObjects.honda);
+            var stream = serializer.Serialize(ruler);
             IIonStruct serialized = StreamToIonValue(stream);
-            Assert.IsTrue(serialized.ContainsField("color"));
+            Assert.IsTrue(serialized.ContainsField("size"));
+            
+            // Note that GetSize() returns size + 10.
+            Assert.AreEqual(ruler.GetSize(), serialized.GetField("size").IntValue);
 
-            var deserialized = serializer.Deserialize<Car>(stream);
-            Assert.AreEqual(TestObjects.honda.GetColor(), deserialized.color);
+            // The setter subtracts 10 when setting the size which will cancel out the 10 added by the getter.
+            var deserialized = serializer.Deserialize<Ruler>(stream);
+            Assert.AreEqual(ruler.size, deserialized.size);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -120,7 +120,6 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             stream.Position = 0;
             var deserialized = serializer.Deserialize<Car>(stream);
-            Assert.IsNotNull(deserialized.color);
             Assert.AreEqual(TestObjects.honda.GetColor(), deserialized.color);
         }
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -363,28 +363,6 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
-    public class Ruler
-    {
-        internal int size;
-
-        [IonPropertyGetter("size")]
-        public int GetSize() 
-        {
-            return this.size + 10;
-        }
-    
-        [IonPropertySetter("size")]
-        public void SetSize(int input) 
-        {
-            this.size = input - 10;
-        }
-        
-        public override string ToString()
-        {
-            return $"<Ruler>{{ size: {this.size} }}";
-        }
-    }
-
     public class Country
     {
         public string Name { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -181,7 +181,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
     public class Car
     {
-        private string color;
+        public string color;
 
         public string Make { get; init; }
         public string Model { get; init; }
@@ -194,11 +194,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         [IonPropertyName("weightInKg")]
         public double Weight { get; init; }
 
+        [IonPropertyGetter("color")]
         public string GetColor() 
         {
             return "#FF0000";
         }
 
+        [IonPropertySetter("color")]
         public void SetColor(string input) 
         {
             this.color = input;

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -181,7 +181,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
     public class Car
     {
-        internal string color;
+        private string color;
 
         public string Make { get; init; }
         public string Model { get; init; }
@@ -194,13 +194,11 @@ namespace Amazon.Ion.ObjectMapper.Test
         [IonPropertyName("weightInKg")]
         public double Weight { get; init; }
 
-        [IonPropertyGetter("color")]
         public string GetColor() 
         {
             return "#FF0000";
         }
 
-        [IonPropertySetter("color")]
         public void SetColor(string input) 
         {
             this.color = input;

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -181,7 +181,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
     public class Car
     {
-        public string color;
+        internal string color;
 
         public string Make { get; init; }
         public string Model { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -341,6 +341,28 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
+    public class Ruler
+    {
+        internal int size;
+
+        [IonPropertyGetter("size")]
+        public int GetSize() 
+        {
+            return this.size + 10;
+        }
+    
+        [IonPropertySetter("size")]
+        public void SetSize(int input) 
+        {
+            this.size = input - 10;
+        }
+        
+        public override string ToString()
+        {
+            return $"<Ruler>{{ size: {this.size} }}";
+        }
+    }
+
     public class Country
     {
         public string Name { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -92,9 +92,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static IIonValue StreamToIonValue(Stream stream)
         {
-            var ion = IonLoader.Default.Load(stream);
-            stream.Position = 0;
-            return ion.GetElementAt(0);
+            return IonLoader.Default.Load(Copy(stream)).GetElementAt(0);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -70,7 +70,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasAnnotation(string annotation, Stream stream)
         {
-            AssertHasAnnotation(annotation, StreamToIonValue(Copy(stream)));
+            AssertHasAnnotation(annotation, StreamToIonValue(stream));
         }
 
         public static void AssertHasAnnotation(string annotation, IIonValue ionValue)
@@ -81,7 +81,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasNoAnnotations(Stream stream)
         {
-            var count = StreamToIonValue(Copy(stream)).GetTypeAnnotationSymbols().Count;
+            var count = StreamToIonValue(stream).GetTypeAnnotationSymbols().Count;
             Assert.IsTrue(count == 0, "Has " + count + " annotations");
         }
 
@@ -92,7 +92,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static IIonValue StreamToIonValue(Stream stream)
         {
-            return IonLoader.Default.Load(stream).GetElementAt(0);
+            IIonValue returnValue = IonLoader.Default.Load(stream).GetElementAt(0);
+            stream.Position = 0;
+            return returnValue;
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -92,9 +92,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static IIonValue StreamToIonValue(Stream stream)
         {
-            IIonValue returnValue = IonLoader.Default.Load(stream).GetElementAt(0);
+            var ion = IonLoader.Default.Load(stream);
             stream.Position = 0;
-            return returnValue;
+            return ion.GetElementAt(0);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/Attributes.cs
+++ b/Amazon.Ion.ObjectMapper/Attributes.cs
@@ -36,6 +36,26 @@ namespace Amazon.Ion.ObjectMapper
         public string Name { get; }
     }
 
+    public class IonPropertyGetter : Attribute
+    {
+        public IonPropertyGetter(string fieldName)
+        {
+            this.FieldName = fieldName;
+        }
+
+        public string FieldName { get; }
+    }
+    
+    public class IonPropertySetter : Attribute
+    {
+        public IonPropertySetter(string fieldName)
+        {
+            FieldName = fieldName;
+        }
+
+        public string FieldName { get; }
+    }
+
     public class IonField : Attribute
     {
     }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -32,7 +32,7 @@ namespace Amazon.Ion.ObjectMapper
                 FieldInfo field;
                 MethodInfo method;
                 
-                // Check if current ion field is a .NET property
+                // Check if current Ion field is a .NET property
                 if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
@@ -44,7 +44,7 @@ namespace Amazon.Ion.ObjectMapper
                     
                     property.SetValue(targetObject, deserialized);
                 }
-                // Check if current ion field is a .NET field
+                // Check if current Ion field is a .NET field
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, field.FieldType, ionType);
@@ -60,7 +60,7 @@ namespace Amazon.Ion.ObjectMapper
 
                     field.SetValue(targetObject, deserialized);
                 }
-                // Check if current ion field has a setter method
+                // Check if current Ion field has a setter method
                 else if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
                     // A setter should be a void method

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -63,7 +63,20 @@ namespace Amazon.Ion.ObjectMapper
                 // Check if current ion field has a setter method
                 else if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
-                    var deserialized = ionSerializer.Deserialize(reader, method.GetParameters()[0].ParameterType, ionType);
+                    // A setter should be a void method
+                    if (method.ReturnParameter == null || method.ReturnParameter.ParameterType != typeof(void))
+                    {
+                        continue;
+                    }
+
+                    // A setter should have exactly one argument
+                    var parameters = method.GetParameters();
+                    if (parameters.Length != 1)
+                    {
+                        continue;
+                    }
+
+                    var deserialized = ionSerializer.Deserialize(reader, parameters[0].ParameterType, ionType);
                     method.Invoke(targetObject, new[]{ deserialized });
                 }
             }
@@ -195,13 +208,8 @@ namespace Amazon.Ion.ObjectMapper
         {
             return targetType.GetMethods().FirstOrDefault(m =>
             {
-                // A setter should be a one argument void method with the IonPropertySetter attribute
                 var setMethod = (IonPropertySetter)m.GetCustomAttribute(typeof(IonPropertySetter));
-                return setMethod != null && 
-                       setMethod.FieldName == name &&
-                       m.ReturnParameter != null && 
-                       m.ReturnParameter.ParameterType == typeof(void) && 
-                       m.GetParameters().Length == 1;
+                return setMethod != null && setMethod.FieldName == name;
             });
         }
 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -28,10 +28,12 @@ namespace Amazon.Ion.ObjectMapper
             IonType ionType;
             while ((ionType = reader.MoveNext()) != IonType.None)
             {
-                var property = FindProperty(reader.CurrentFieldName);
+                PropertyInfo property;
                 FieldInfo field;
                 MethodInfo method;
-                if (property != null)
+                
+                // Check if current ion field is a .NET property
+                if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
                     
@@ -42,6 +44,7 @@ namespace Amazon.Ion.ObjectMapper
                     
                     property.SetValue(targetObject, deserialized);
                 }
+                // Check if current ion field is a .NET field
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, field.FieldType, ionType);
@@ -57,7 +60,8 @@ namespace Amazon.Ion.ObjectMapper
 
                     field.SetValue(targetObject, deserialized);
                 }
-                else if ((method = FindSetterMethod(reader.CurrentFieldName)) != null)
+                // Check if current ion field has a setter method
+                else if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, method.GetParameters()[0].ParameterType, ionType);
                     method.Invoke(targetObject, new[]{ deserialized });
@@ -71,6 +75,8 @@ namespace Amazon.Ion.ObjectMapper
         {
             options.TypeAnnotator.Apply(options, writer, targetType);
             writer.StepIn(IonType.Struct);
+            
+            // Serialize any properties that satisfy the options/attributes
             foreach (var property in targetType.GetProperties())
             {
                 if (property.GetCustomAttributes(true).Any(it => it is IonIgnore))
@@ -92,6 +98,7 @@ namespace Amazon.Ion.ObjectMapper
                 ionSerializer.Serialize(writer, propertyValue);
             }
 
+            // Serialize any fields that satisfy the options/attributes
             foreach (var field in Fields())
             {
                 var fieldValue = field.GetValue(item);
@@ -112,6 +119,8 @@ namespace Amazon.Ion.ObjectMapper
                 ionSerializer.Serialize(writer, fieldValue);
             }
 
+            // Serialize the values returned from getter methods
+            // as long as they have zero arguments and are annotated with the IonPropertyGetter attribute.
             foreach (var method in targetType.GetMethods())
             {
                 var getMethod = (IonPropertyGetter)method.GetCustomAttribute(typeof(IonPropertyGetter));
@@ -182,10 +191,11 @@ namespace Amazon.Ion.ObjectMapper
             });
         }
 
-        private MethodInfo FindSetterMethod(string name)
+        private MethodInfo FindSetter(string name)
         {
             return targetType.GetMethods().FirstOrDefault(m =>
             {
+                // A setter should be a one argument void method with the IonPropertySetter attribute
                 var setMethod = (IonPropertySetter)m.GetCustomAttribute(typeof(IonPropertySetter));
                 return setMethod != null && 
                        setMethod.FieldName == name &&


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/10.

By default, C# methods are ignored, however, provided the “get” signature is a no-argument method and the “set” signature is a one-argument void method, methods can be use to get and set properties. The Ion property name must be specified and will not be inferred from the method name.

```c#
public class Car
{
    private string color;
    
    [IonPropertyGetter("color")]
    public string GetColor() 
    {
        return "#FF0000";
    }
    
    [IonPropertySetter("color")]
    public void SetColor(string input) 
    {
        this.color = input;
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
