### PR TITLE
Implement IonSerializers option for custom serializers

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -61,6 +61,30 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void SerializesObjectsWithIgnoreDefaults()
+        {
+            var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
+            IIonStruct serialized = StreamToIonValue(serializer.Serialize(new Motorcycle {canOffroad = true}));
+
+            Assert.IsFalse(serialized.ContainsField("Brand"));
+            Assert.IsFalse(serialized.ContainsField("color"));
+            Assert.IsTrue(serialized.ContainsField("canOffroad"));
+        }
+        
+        [TestMethod]
+        public void DeserializesObjectsWithIgnoreDefaults()
+        {
+            var stream = new IonSerializer().Serialize(new Motorcycle {canOffroad = true});
+
+            var serializer = new IonSerializer(new IonSerializationOptions {IgnoreDefaults = true});
+            var deserialized = serializer.Deserialize<Motorcycle>(stream);
+            
+            Assert.IsNull(deserialized.Brand);
+            Assert.IsNull(deserialized.color);
+            Assert.IsNotNull(deserialized.canOffroad);
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesFields()
         {
             Check(TestObjects.registration);

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Amazon.IonDotnet;
 using Amazon.IonDotnet.Tree;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Amazon.Ion.ObjectMapper.Test.Utils;
@@ -159,6 +162,472 @@ namespace Amazon.Ion.ObjectMapper.Test
             AssertHasAnnotation(
                 "my.universal.namespace.BussyMcBusface", 
                 new IonSerializer().Serialize(new Bus()));
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomBoolSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(bool), new NegationBoolIonSerializer()},
+                }
+            });
+            
+            var testBool = true;
+            
+            var stream = customSerializer.Serialize(testBool);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(!testBool, serialized.BoolValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomBoolSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(bool), new NegationBoolIonSerializer()},
+                }
+            });
+            
+            var testBool = true;
+
+            var stream = defaultSerializer.Serialize(testBool);
+            var deserialized = customSerializer.Deserialize<bool>(stream);
+            Assert.AreEqual(!testBool, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomStringSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(string), new UpperCaseStringIonSerializer()},
+                }
+            });
+
+            var testStr = "test string";
+
+            var stream = customSerializer.Serialize(testStr);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(testStr.ToUpper(), serialized.StringValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomStringSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(string), new UpperCaseStringIonSerializer()},
+                }
+            });
+
+            var testStr = "test string";
+
+            var stream = defaultSerializer.Serialize(testStr);
+            var deserialized = customSerializer.Deserialize<string>(stream);
+            Assert.AreEqual(testStr.ToUpper(), deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomByteArraySerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(byte[]), new ZeroByteArrayIonSerializer()},
+                }
+            });
+
+            var testArr = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26 };
+            var expectedArr = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+            var stream = customSerializer.Serialize(testArr);
+            var serialized = StreamToIonValue(stream);
+            Assert.IsTrue(expectedArr.SequenceEqual(serialized.Bytes().ToArray()));
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomByteArraySerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(byte[]), new ZeroByteArrayIonSerializer()},
+                }
+            });
+
+            var testArr = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26 };
+            var expectedArr = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+            var stream = defaultSerializer.Serialize(testArr);
+            var deserialized = customSerializer.Deserialize<byte[]>(stream);
+            Assert.IsTrue(expectedArr.SequenceEqual(deserialized));
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomIntSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(int), new NegativeIntIonSerializer()},
+                }
+            });
+            
+            var testInt = 15;
+            
+            var stream = customSerializer.Serialize(testInt);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testInt, serialized.IntValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomIntSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(int), new NegativeIntIonSerializer()},
+                }
+            });
+            
+            var testInt = 15;
+
+            var stream = defaultSerializer.Serialize(testInt);
+            var deserialized = customSerializer.Deserialize<int>(stream);
+            Assert.AreEqual(-testInt, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomLongSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(long), new NegativeLongIonSerializer()},
+                }
+            });
+            
+            var testLong = 9223372036854775807;
+            
+            var stream = customSerializer.Serialize(testLong);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testLong, serialized.LongValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomLongSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(long), new NegativeLongIonSerializer()},
+                }
+            });
+            
+            var testLong = 9223372036854775807;
+
+            var stream = defaultSerializer.Serialize(testLong);
+            var deserialized = customSerializer.Deserialize<long>(stream);
+            Assert.AreEqual(-testLong, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomFloatSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(float), new NegativeFloatIonSerializer()},
+                }
+            });
+            
+            var testFloat = (float)3.14;
+            
+            var stream = customSerializer.Serialize(testFloat);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testFloat, serialized.DoubleValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomFloatSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(float), new NegativeFloatIonSerializer()},
+                }
+            });
+            
+            var testFloat = (float)3.14;
+
+            var stream = defaultSerializer.Serialize(testFloat);
+            var deserialized = customSerializer.Deserialize<float>(stream);
+            Assert.AreEqual(-testFloat, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomDoubleSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(double), new NegativeDoubleIonSerializer()},
+                }
+            });
+            
+            var testFloat = 3.14;
+            
+            var stream = customSerializer.Serialize(testFloat);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testFloat, serialized.DoubleValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomDoubleSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(double), new NegativeDoubleIonSerializer()},
+                }
+            });
+            
+            var testFloat = 3.14;
+
+            var stream = defaultSerializer.Serialize(testFloat);
+            var deserialized = customSerializer.Deserialize<double>(stream);
+            Assert.AreEqual(-testFloat, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomDecimalSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(decimal), new NegativeDecimalIonSerializer()},
+                }
+            });
+            
+            var testDecimal = (decimal)3.14;
+            
+            var stream = customSerializer.Serialize(testDecimal);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testDecimal, serialized.DecimalValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomDecimalSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(decimal), new NegativeDecimalIonSerializer()},
+                }
+            });
+            
+            var testDecimal = (decimal)3.14;
+
+            var stream = defaultSerializer.Serialize(testDecimal);
+            var deserialized = customSerializer.Deserialize<decimal>(stream);
+            Assert.AreEqual(-testDecimal, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomBigDecimalSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(BigDecimal), new NegativeBigDecimalIonSerializer()},
+                }
+            });
+
+            var testBigDecimal = BigDecimal.Parse("3.14159265359");
+            
+            var stream = customSerializer.Serialize(testBigDecimal);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(-testBigDecimal, serialized.BigDecimalValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomBigDecimalSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(BigDecimal), new NegativeBigDecimalIonSerializer()},
+                }
+            });
+            
+            var testBigDecimal = BigDecimal.Parse("3.14159265359");
+
+            var stream = defaultSerializer.Serialize(testBigDecimal);
+            var deserialized = customSerializer.Deserialize<BigDecimal>(stream);
+            Assert.AreEqual(-testBigDecimal, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomSymbolSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(SymbolToken), new UpperCaseSymbolIonSerializer()},
+                }
+            });
+
+            var testSymbol = new SymbolToken("test symbol", 10);
+
+            var stream = customSerializer.Serialize(testSymbol);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(testSymbol.Text.ToUpper(), serialized.SymbolValue.Text);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomSymbolSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(SymbolToken), new UpperCaseSymbolIonSerializer()},
+                }
+            });
+
+            var testSymbol = new SymbolToken("test symbol", 10);
+
+            var stream = defaultSerializer.Serialize(testSymbol);
+            var deserialized = customSerializer.Deserialize<SymbolToken>(stream);
+            Assert.AreEqual(testSymbol.Text.ToUpper(), deserialized.Text);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomDateSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(DateTime), new NextDayDateTimeIonSerializer()},
+                }
+            });
+
+            var testDate = new DateTime(2005, 05, 23);
+            var expectedDate = testDate.AddDays(1);
+
+            var stream = customSerializer.Serialize(testDate);
+            var serialized = StreamToIonValue(stream);
+            Assert.AreEqual(expectedDate, serialized.TimestampValue.DateTimeValue);
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomDateSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(DateTime), new NextDayDateTimeIonSerializer()},
+                }
+            });
+
+            var testDate = new DateTime(2005, 05, 23);
+            var expectedDate = testDate.AddDays(1);
+
+            var stream = defaultSerializer.Serialize(testDate);
+            var deserialized = customSerializer.Deserialize<DateTime>(stream);
+            Assert.AreEqual(expectedDate, deserialized);
+        }
+        
+        [TestMethod]
+        public void SerializesWithCustomGuidSerializer()
+        {
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(Guid), new ZeroGuidIonSerializer()},
+                }
+            });
+
+            var testGuid = new Guid(new byte[] 
+            { 
+                0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+                0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F
+            });
+            var expectedGuid = new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            };
+
+            var stream = customSerializer.Serialize(testGuid);
+            var serialized = StreamToIonValue(stream);
+            Assert.IsTrue(expectedGuid.SequenceEqual(serialized.Bytes().ToArray()));
+        }
+        
+        [TestMethod]
+        public void DeserializesWithCustomGuidSerializer()
+        {
+            var defaultSerializer = new IonSerializer();
+            var customSerializer = new IonSerializer(new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    {typeof(Guid), new ZeroGuidIonSerializer()},
+                }
+            });
+
+            var testGuid = new Guid(new byte[] 
+            { 
+                0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+                0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F
+            });
+            var expectedGuid = new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            };
+
+            var stream = defaultSerializer.Serialize(testGuid);
+            var deserialized = customSerializer.Deserialize<Guid>(stream);
+            Assert.IsTrue(expectedGuid.SequenceEqual(deserialized.ToByteArray()));
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -687,5 +687,20 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.AreEqual(-TestObjects.honda.Weight, deserialized.Weight);
             Assert.AreEqual(TestObjects.honda.Engine.ManufactureDate.AddDays(1), deserialized.Engine.ManufactureDate);
         }
+        
+        [TestMethod]
+        public void ExceptionOnInvalidCustomSerializer()
+        {
+            var options = new IonSerializationOptions
+            {
+                IonSerializers = new Dictionary<Type, dynamic>()
+                {
+                    // An int serializer should not be valid for type string
+                    {typeof(string), new NegativeIntIonSerializer()},
+                }
+            };
+
+            Assert.ThrowsException<NotSupportedException>(() => new IonSerializer(options));
+        }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Amazon.IonDotnet.Tree;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -83,52 +82,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNull(deserialized.Brand);
             Assert.IsNull(deserialized.color);
             Assert.IsNotNull(deserialized.canOffroad);
-        }
-        
-        [TestMethod]
-        public void SerializesAndDeserializesWithCustomSerializers()
-        {
-            var defaultSerializer = new IonSerializer();
-            var customSerializer = new IonSerializer(new IonSerializationOptions
-            {
-                IonSerializers = new Dictionary<Type, dynamic>()
-                {
-                    {typeof(string), new UpperCaseStringIonSerializer()},
-                    {typeof(int), new NegativeIntIonSerializer()},
-                }
-            });
-
-            var testStr = "test string";
-
-            var stream = customSerializer.Serialize(testStr);
-            var serializedStr = StreamToIonValue(stream);
-            Assert.AreEqual(testStr.ToUpper(), serializedStr.StringValue);
-
-            stream = defaultSerializer.Serialize(testStr);
-            var deserializedStr = customSerializer.Deserialize<string>(stream);
-            Assert.AreEqual(testStr.ToUpper(), deserializedStr);
-
-            var testInt = 15;
-            
-            stream = customSerializer.Serialize(testInt);
-            var serializedInt = StreamToIonValue(stream);
-            Assert.AreEqual(-testInt, serializedInt.IntValue);
-            
-            stream = defaultSerializer.Serialize(testInt);
-            var deserializedInt = customSerializer.Deserialize<int>(stream);
-            Assert.AreEqual(-testInt, deserializedInt);
-            
-            stream = customSerializer.Serialize(TestObjects.honda);
-            var serializedCar = StreamToIonValue(stream);
-            Assert.IsTrue(serializedCar.ContainsField("make"));
-            Assert.AreEqual(TestObjects.honda.Make.ToUpper(), serializedCar.GetField("make").StringValue);
-            Assert.IsTrue(serializedCar.ContainsField("yearOfManufacture"));
-            Assert.AreEqual(-TestObjects.honda.YearOfManufacture, serializedCar.GetField("yearOfManufacture").IntValue);
-            
-            stream = defaultSerializer.Serialize(TestObjects.honda);
-            var deserializedCar = customSerializer.Deserialize<Car>(stream);
-            Assert.AreEqual(TestObjects.honda.Make.ToUpper(), deserializedCar.Make);
-            Assert.AreEqual(-TestObjects.honda.YearOfManufacture, deserializedCar.YearOfManufacture);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.IonDotnet;
 
 namespace Amazon.Ion.ObjectMapper.Test
 {
@@ -284,6 +285,32 @@ namespace Amazon.Ion.ObjectMapper.Test
         public override string ToString()
         {
             return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + ", birthDate: " + birthDate + " }";
+        }
+    }
+    
+    public class UpperCaseStringIonSerializer : IonSerializer<string>
+    {
+        public string Deserialize(IIonReader reader)
+        {
+            return reader.StringValue().ToUpper();
+        }
+
+        public void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString(item.ToUpper());
+        }
+    }
+    
+    public class NegativeIntIonSerializer : IonSerializer<int>
+    {
+        public int Deserialize(IIonReader reader)
+        {
+            return -reader.IntValue();
+        }
+
+        public void Serialize(IIonWriter writer, int item)
+        {
+            writer.WriteInt(-item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -369,6 +369,32 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string LastName { get; init; }
     }
   
+    public class NegationBoolIonSerializer : IonSerializer<bool>
+    {
+        public bool Deserialize(IIonReader reader)
+        {
+            return !reader.BoolValue();
+        }
+
+        public void Serialize(IIonWriter writer, bool item)
+        {
+            writer.WriteBool(!item);
+        }
+    }
+    
+    public class ZeroByteArrayIonSerializer : IonSerializer<byte[]>
+    {
+        public byte[] Deserialize(IIonReader reader)
+        {
+            return new byte[reader.GetLobByteSize()];
+        }
+
+        public void Serialize(IIonWriter writer, byte[] item)
+        {
+            writer.WriteBlob(new byte[item.Length]);
+        }
+    }
+    
     public class UpperCaseStringIonSerializer : IonSerializer<string>
     {
         public string Deserialize(IIonReader reader)
@@ -392,6 +418,113 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void Serialize(IIonWriter writer, int item)
         {
             writer.WriteInt(-item);
+        }
+    }
+    
+    public class NegativeLongIonSerializer : IonSerializer<long>
+    {
+        public long Deserialize(IIonReader reader)
+        {
+            return -reader.LongValue();
+        }
+
+        public void Serialize(IIonWriter writer, long item)
+        {
+            writer.WriteInt(-item);
+        }
+    }
+    
+    public class NegativeFloatIonSerializer : IonSerializer<float>
+    {
+        public float Deserialize(IIonReader reader)
+        {
+            return -Convert.ToSingle(reader.DoubleValue());
+        }
+
+        public void Serialize(IIonWriter writer, float item)
+        {
+            writer.WriteFloat(-item);
+        }
+    }
+    
+    public class NegativeDoubleIonSerializer : IonSerializer<double>
+    {
+        public double Deserialize(IIonReader reader)
+        {
+            return -reader.DoubleValue();
+        }
+
+        public void Serialize(IIonWriter writer, double item)
+        {
+            writer.WriteFloat(-item);
+        }
+    }
+    
+    public class NegativeDecimalIonSerializer : IonSerializer<decimal>
+    {
+        public decimal Deserialize(IIonReader reader)
+        {
+            return -reader.DecimalValue().ToDecimal();
+        }
+
+        public void Serialize(IIonWriter writer, decimal item)
+        {
+            writer.WriteDecimal(-item);
+        }
+    }
+    
+    public class NegativeBigDecimalIonSerializer : IonSerializer<BigDecimal>
+    {
+        public BigDecimal Deserialize(IIonReader reader)
+        {
+            return -reader.DecimalValue();
+        }
+
+        public void Serialize(IIonWriter writer, BigDecimal item)
+        {
+            writer.WriteDecimal(-item);
+        }
+    }
+    
+    public class UpperCaseSymbolIonSerializer : IonSerializer<SymbolToken>
+    {
+        public SymbolToken Deserialize(IIonReader reader)
+        {
+            var token = reader.SymbolValue();
+            return new SymbolToken(token.Text.ToUpper(), token.Sid);
+        }
+
+        public void Serialize(IIonWriter writer, SymbolToken item)
+        {
+            var token = new SymbolToken(item.Text.ToUpper(), item.Sid);
+            writer.WriteSymbolToken(token);
+        }
+    }
+    
+    public class NextDayDateTimeIonSerializer : IonSerializer<DateTime>
+    {
+        public DateTime Deserialize(IIonReader reader)
+        {
+            return reader.TimestampValue().DateTimeValue.AddDays(1);
+        }
+
+        public void Serialize(IIonWriter writer, DateTime item)
+        {
+            writer.WriteTimestamp(new Timestamp(item.AddDays(1)));
+        }
+    }
+    
+    public class ZeroGuidIonSerializer : IonSerializer<Guid>
+    {
+        public Guid Deserialize(IIonReader reader)
+        {
+            byte[] blob = new byte[reader.GetLobByteSize()];
+            return new Guid(blob);
+        }
+
+        public void Serialize(IIonWriter writer, Guid item)
+        {
+            writer.WriteBlob(new byte[item.ToByteArray().Length]);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -46,12 +46,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
     
+    [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Motorcycle : Vehicle
     {
         public string Brand { get; init; }
 
         [IonField]
-        private string color;
+        public string color;
 
         [IonField]
         public bool canOffroad; 

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -97,14 +97,19 @@ namespace Amazon.Ion.ObjectMapper
             throw new NotSupportedException("Don't know how to make a list of type " + listType + " with element type " + elementType);
         }
 
-        public void Serialize(IIonWriter writer, object item)
+        public void Serialize(IIonWriter writer, IList item)
         {
             writer.StepIn(IonType.List);
-            foreach (var i in (System.Collections.IList)item)
+            foreach (var i in item)
             {
                 serializer.Serialize(writer, i);
             }
             writer.StepOut();
+        }
+        
+        public void Serialize(IIonWriter writer, object item)
+        {
+            this.Serialize(writer, (IList)item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -12,24 +12,9 @@ namespace Amazon.Ion.ObjectMapper
         private Type elementType;
         private bool isGenericList;
 
-        public IonListSerializer(IonSerializer serializer)
-        {
-            this.serializer = serializer;
-        }
-
         public IonListSerializer(IonSerializer serializer, Type listType)
         {
             this.serializer = serializer;
-            this.SetListType(listType);
-        }
-        
-        internal void SetListType(Type listType)
-        {
-            if (listType == this.listType)
-            {
-                return;
-            }
-
             this.listType = listType;
 
             if (this.listType.IsArray)
@@ -54,7 +39,7 @@ namespace Amazon.Ion.ObjectMapper
         public IList Deserialize(IIonReader reader)
         {
             reader.StepIn();
-            var list = new System.Collections.ArrayList();
+            var list = new ArrayList();
             IonType ionType;
             while ((ionType = reader.MoveNext()) != IonType.None)
             {
@@ -72,14 +57,14 @@ namespace Amazon.Ion.ObjectMapper
                 return typedArray;
             }
             
-            if (listType is System.Collections.IEnumerable || listType is object)
+            if (listType is IEnumerable || listType is object)
             {
-                System.Collections.IList typedList;
+                IList typedList;
                 if (listType.IsGenericType) 
                 {
-                    typedList = (System.Collections.IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
+                    typedList = (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
                 } else {
-                    typedList = new System.Collections.ArrayList();
+                    typedList = new ArrayList();
                 }
 
                 foreach (var element in list)

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -8,9 +8,9 @@ namespace Amazon.Ion.ObjectMapper
     public class IonListSerializer : IonSerializer<IList>
     {
         private readonly IonSerializer serializer;
-        private Type listType;
-        private Type elementType;
-        private bool isGenericList;
+        private readonly Type listType;
+        private readonly Type elementType;
+        private readonly bool isGenericList;
 
         public IonListSerializer(IonSerializer serializer, Type listType)
         {

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -87,10 +87,5 @@ namespace Amazon.Ion.ObjectMapper
             }
             writer.StepOut();
         }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            this.Serialize(writer, (IList)item);
-        }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -68,10 +68,10 @@ namespace Amazon.Ion.ObjectMapper
             throw new NotSupportedException("Don't know how to make a list of type " + listType + " with element type " + elementType);
         }
 
-        public void Serialize(IIonWriter writer, System.Collections.IList item)
+        public void Serialize(IIonWriter writer, object item)
         {
             writer.StepIn(IonType.List);
-            foreach (var i in item)
+            foreach (var i in (System.Collections.IList)item)
             {
                 serializer.Serialize(writer, i);
             }

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -32,21 +32,17 @@ namespace Amazon.Ion.ObjectMapper
 
             this.listType = listType;
 
-            if (listType.IsArray)
+            if (this.listType.IsArray)
             {
-                this.elementType = listType.GetElementType();
+                this.elementType = this.listType.GetElementType();
                 this.isGenericList = true;
             }
-            else if (listType.IsAssignableTo(typeof(IList)))
+            else if (this.listType.IsAssignableTo(typeof(IList)))
             {
-                if (listType.IsGenericType)
+                this.isGenericList = this.listType.IsGenericType;
+                if (this.isGenericList)
                 {
-                    this.elementType = listType.GetGenericArguments()[0];
-                    this.isGenericList = true;
-                }
-                else
-                {
-                    this.isGenericList = false;
+                    this.elementType = this.listType.GetGenericArguments()[0];
                 }
             }
             else

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -33,6 +33,12 @@ namespace Amazon.Ion.ObjectMapper
                 if (property != null)
                 {
                     var deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
+                    
+                    if (options.IgnoreDefaults && deserialized == default)
+                    {
+                        continue;
+                    }
+                    
                     property.SetValue(targetObject, deserialized);
                 }
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
@@ -43,7 +49,11 @@ namespace Amazon.Ion.ObjectMapper
                     {
                         continue;
                     }
-                    
+                    if (options.IgnoreDefaults && deserialized == default)
+                    {
+                        continue;
+                    }
+
                     field.SetValue(targetObject, deserialized);
                 }
             }
@@ -67,6 +77,10 @@ namespace Amazon.Ion.ObjectMapper
                 {
                     continue;
                 }
+                if (options.IgnoreDefaults && propertyValue == default)
+                {
+                    continue;
+                }
 
                 writer.SetFieldName(IonFieldNameFromProperty(property));
                 ionSerializer.Serialize(writer, propertyValue);
@@ -80,6 +94,10 @@ namespace Amazon.Ion.ObjectMapper
                     continue;
                 }
                 if (options.IgnoreReadOnlyFields && field.IsInitOnly)
+                {
+                    continue;
+                }
+                if (options.IgnoreDefaults && fieldValue == default)
                 {
                     continue;
                 }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -11,14 +11,7 @@ namespace Amazon.Ion.ObjectMapper
         private const BindingFlags fieldBindings = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
         private readonly IonSerializer ionSerializer;
         private readonly IonSerializationOptions options;
-        internal Type targetType;
-
-        public IonObjectSerializer(IonSerializer ionSerializer)
-        {
-            this.ionSerializer = ionSerializer;
-            this.options = ionSerializer.options;
-            this.targetType = default;
-        }
+        private readonly Type targetType;
 
         public IonObjectSerializer(IonSerializer ionSerializer, IonSerializationOptions options, Type targetType)
         {

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -11,7 +11,14 @@ namespace Amazon.Ion.ObjectMapper
         private const BindingFlags fieldBindings = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
         private readonly IonSerializer ionSerializer;
         private readonly IonSerializationOptions options;
-        private readonly Type targetType;
+        internal Type targetType;
+
+        public IonObjectSerializer(IonSerializer ionSerializer)
+        {
+            this.ionSerializer = ionSerializer;
+            this.options = ionSerializer.options;
+            this.targetType = default;
+        }
 
         public IonObjectSerializer(IonSerializer ionSerializer, IonSerializationOptions options, Type targetType)
         {

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -28,9 +28,9 @@ namespace Amazon.Ion.ObjectMapper
             return blob;
         }
 
-        public void Serialize(IIonWriter writer, byte[] item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteBlob(item);
+            writer.WriteBlob((byte[])item);
         }
     }
     public class IonStringSerializer : IonSerializer<string>
@@ -40,9 +40,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.StringValue();
         }
 
-        public void Serialize(IIonWriter writer, string item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteString(item);
+            writer.WriteString(item as string);
         }
     }
 
@@ -53,9 +53,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.IntValue();
         }
 
-        public void Serialize(IIonWriter writer, int item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteInt(item);
+            writer.WriteInt(Convert.ToInt32(item));
         }
     }
 
@@ -68,10 +68,10 @@ namespace Amazon.Ion.ObjectMapper
             return reader.IntValue();
         }
 
-        public void Serialize(IIonWriter writer, long item)
+        public void Serialize(IIonWriter writer, object item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteInt(item);
+            writer.WriteInt(Convert.ToInt64(item));
         }
     }
     public class IonBooleanSerializer : IonSerializer<bool>
@@ -81,9 +81,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.BoolValue();
         }
 
-        public void Serialize(IIonWriter writer, bool item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteBool(item);
+            writer.WriteBool(Convert.ToBoolean(item));
         }
     }
 
@@ -94,9 +94,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DoubleValue();
         }
 
-        public void Serialize(IIonWriter writer, double item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteFloat(item);
+            writer.WriteFloat(Convert.ToDouble(item));
         }
     }
 
@@ -109,10 +109,10 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DecimalValue().ToDecimal();
         }
 
-        public void Serialize(IIonWriter writer, decimal item)
+        public void Serialize(IIonWriter writer, object item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteDecimal(item);
+            writer.WriteDecimal(Convert.ToDecimal(item));
         }
     }
 
@@ -123,9 +123,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DecimalValue();
         }
 
-        public void Serialize(IIonWriter writer, BigDecimal item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteDecimal(item);
+            writer.WriteDecimal((BigDecimal)item);
         }
     }
 
@@ -139,10 +139,10 @@ namespace Amazon.Ion.ObjectMapper
             return Convert.ToSingle(reader.DoubleValue());
         }
 
-        public void Serialize(IIonWriter writer, float item)
+        public void Serialize(IIonWriter writer, object item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteFloat(item);
+            writer.WriteFloat(Convert.ToSingle(item));
         }
     }
 
@@ -153,9 +153,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.TimestampValue().DateTimeValue;
         }
 
-        public void Serialize(IIonWriter writer, DateTime item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteTimestamp(new Timestamp(item));
+            writer.WriteTimestamp(new Timestamp((DateTime)item));
         }
     }
 
@@ -166,9 +166,9 @@ namespace Amazon.Ion.ObjectMapper
             return reader.SymbolValue();
         }
 
-        public void Serialize(IIonWriter writer, SymbolToken item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteSymbolToken(item);
+            writer.WriteSymbolToken((SymbolToken)item);
         }
     }
 
@@ -181,20 +181,20 @@ namespace Amazon.Ion.ObjectMapper
             return Encoding.UTF8.GetString(clob);
         }
 
-        public void Serialize(IIonWriter writer, string item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            writer.WriteClob(Encoding.UTF8.GetBytes(item));
+            writer.WriteClob(Encoding.UTF8.GetBytes(item as string));
         }
     }
 
     public class IonGuidSerializer : IonSerializer<Guid>
     {
         internal static readonly string ANNOTATION = "guid128";
-        private IonSerializationOptions options;
+        private readonly bool annotateGuids;
 
-        public IonGuidSerializer(IonSerializationOptions options)
+        public IonGuidSerializer(bool annotateGuids)
         {
-            this.options = options;
+            this.annotateGuids = annotateGuids;
         }
 
         public Guid Deserialize(IIonReader reader)
@@ -204,12 +204,12 @@ namespace Amazon.Ion.ObjectMapper
             return new Guid(blob);
         }
 
-        public void Serialize(IIonWriter writer, Guid item)
+        public void Serialize(IIonWriter writer, object item)
         {
-            if (options.AnnotateGuids) {
+            if (annotateGuids) {
                 writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             }
-            writer.WriteBlob(item.ToByteArray());
+            writer.WriteBlob(((Guid)item).ToByteArray());
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -31,11 +31,6 @@ namespace Amazon.Ion.ObjectMapper
         {
             writer.WriteBlob(item);
         }
-
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteBlob((byte[])item);
-        }
     }
     public class IonStringSerializer : IonSerializer<string>
     {
@@ -47,11 +42,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, string item)
         {
             writer.WriteString(item);
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteString(item as string);
         }
     }
 
@@ -65,11 +55,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, int item)
         {
             writer.WriteInt(item);
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteInt(Convert.ToInt32(item));
         }
     }
 
@@ -87,12 +72,6 @@ namespace Amazon.Ion.ObjectMapper
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteInt(item);
         }
-
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteInt(Convert.ToInt64(item));
-        }
     }
     public class IonBooleanSerializer : IonSerializer<bool>
     {
@@ -104,11 +83,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, bool item)
         {
             writer.WriteBool(item);
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteBool(Convert.ToBoolean(item));
         }
     }
 
@@ -122,11 +96,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, double item)
         {
             writer.WriteFloat(item);
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteFloat(Convert.ToDouble(item));
         }
     }
 
@@ -144,12 +113,6 @@ namespace Amazon.Ion.ObjectMapper
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteDecimal(item);
         }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteDecimal(Convert.ToDecimal(item));
-        }
     }
 
     public class IonBigDecimalSerializer : IonSerializer<BigDecimal>
@@ -162,11 +125,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, BigDecimal item)
         {
             writer.WriteDecimal(item);
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteDecimal((BigDecimal)item);
         }
     }
 
@@ -184,12 +142,6 @@ namespace Amazon.Ion.ObjectMapper
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteFloat(item);
         }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
-            writer.WriteFloat(Convert.ToSingle(item));
-        }
     }
 
     public class IonDateTimeSerializer : IonSerializer<DateTime>
@@ -203,11 +155,6 @@ namespace Amazon.Ion.ObjectMapper
         {
             writer.WriteTimestamp(new Timestamp(item));
         }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteTimestamp(new Timestamp((DateTime)item));
-        }
     }
 
     public class IonSymbolSerializer : IonSerializer<SymbolToken>
@@ -220,11 +167,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, SymbolToken item)
         {
             writer.WriteSymbolToken(item);
-        }
-
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteSymbolToken((SymbolToken)item);
         }
     }
 
@@ -240,11 +182,6 @@ namespace Amazon.Ion.ObjectMapper
         public void Serialize(IIonWriter writer, string item)
         {
             writer.WriteClob(Encoding.UTF8.GetBytes(item));
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            writer.WriteClob(Encoding.UTF8.GetBytes(item as string));
         }
     }
 
@@ -271,11 +208,6 @@ namespace Amazon.Ion.ObjectMapper
                 writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             }
             writer.WriteBlob(item.ToByteArray());
-        }
-        
-        public void Serialize(IIonWriter writer, object item)
-        {
-            this.Serialize(writer, (Guid)item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Generic; 
+using System.Numerics;
 using System.Text;
 using Amazon.IonDotnet;
 
@@ -134,6 +135,7 @@ namespace Amazon.Ion.ObjectMapper
 
         public float Deserialize(IIonReader reader)
         {
+            
             return Convert.ToSingle(reader.DoubleValue());
         }
 
@@ -188,11 +190,11 @@ namespace Amazon.Ion.ObjectMapper
     public class IonGuidSerializer : IonSerializer<Guid>
     {
         internal static readonly string ANNOTATION = "guid128";
-        private readonly bool annotateGuids;
+        private IonSerializationOptions options;
 
-        public IonGuidSerializer(bool annotateGuids)
+        public IonGuidSerializer(IonSerializationOptions options)
         {
-            this.annotateGuids = annotateGuids;
+            this.options = options;
         }
 
         public Guid Deserialize(IIonReader reader)
@@ -204,7 +206,7 @@ namespace Amazon.Ion.ObjectMapper
 
         public void Serialize(IIonWriter writer, Guid item)
         {
-            if (annotateGuids) {
+            if (options.AnnotateGuids) {
                 writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             }
             writer.WriteBlob(item.ToByteArray());

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -65,7 +65,7 @@ namespace Amazon.Ion.ObjectMapper
 
         public long Deserialize(IIonReader reader)
         {
-            return reader.IntValue();
+            return reader.LongValue();
         }
 
         public void Serialize(IIonWriter writer, long item)

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -26,7 +26,7 @@ namespace Amazon.Ion.ObjectMapper
             reader.GetBytes(blob);
             return blob;
         }
-        
+
         public void Serialize(IIonWriter writer, byte[] item)
         {
             writer.WriteBlob(item);
@@ -66,7 +66,7 @@ namespace Amazon.Ion.ObjectMapper
         {
             return reader.IntValue();
         }
-        
+
         public void Serialize(IIonWriter writer, long item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
@@ -163,7 +163,7 @@ namespace Amazon.Ion.ObjectMapper
         {
             return reader.SymbolValue();
         }
-        
+
         public void Serialize(IIonWriter writer, SymbolToken item)
         {
             writer.WriteSymbolToken(item);

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -26,6 +26,11 @@ namespace Amazon.Ion.ObjectMapper
             reader.GetBytes(blob);
             return blob;
         }
+        
+        public void Serialize(IIonWriter writer, byte[] item)
+        {
+            writer.WriteBlob(item);
+        }
 
         public void Serialize(IIonWriter writer, object item)
         {
@@ -39,6 +44,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.StringValue();
         }
 
+        public void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteString(item as string);
@@ -52,6 +62,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.IntValue();
         }
 
+        public void Serialize(IIonWriter writer, int item)
+        {
+            writer.WriteInt(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteInt(Convert.ToInt32(item));
@@ -65,6 +80,12 @@ namespace Amazon.Ion.ObjectMapper
         public long Deserialize(IIonReader reader)
         {
             return reader.IntValue();
+        }
+        
+        public void Serialize(IIonWriter writer, long item)
+        {
+            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
+            writer.WriteInt(item);
         }
 
         public void Serialize(IIonWriter writer, object item)
@@ -80,6 +101,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.BoolValue();
         }
 
+        public void Serialize(IIonWriter writer, bool item)
+        {
+            writer.WriteBool(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteBool(Convert.ToBoolean(item));
@@ -93,6 +119,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DoubleValue();
         }
 
+        public void Serialize(IIonWriter writer, double item)
+        {
+            writer.WriteFloat(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteFloat(Convert.ToDouble(item));
@@ -108,6 +139,12 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DecimalValue().ToDecimal();
         }
 
+        public void Serialize(IIonWriter writer, decimal item)
+        {
+            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
+            writer.WriteDecimal(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
@@ -122,6 +159,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.DecimalValue();
         }
 
+        public void Serialize(IIonWriter writer, BigDecimal item)
+        {
+            writer.WriteDecimal(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteDecimal((BigDecimal)item);
@@ -134,10 +176,15 @@ namespace Amazon.Ion.ObjectMapper
 
         public float Deserialize(IIonReader reader)
         {
-            
             return Convert.ToSingle(reader.DoubleValue());
         }
 
+        public void Serialize(IIonWriter writer, float item)
+        {
+            writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
+            writer.WriteFloat(item);
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
@@ -152,6 +199,11 @@ namespace Amazon.Ion.ObjectMapper
             return reader.TimestampValue().DateTimeValue;
         }
 
+        public void Serialize(IIonWriter writer, DateTime item)
+        {
+            writer.WriteTimestamp(new Timestamp(item));
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteTimestamp(new Timestamp((DateTime)item));
@@ -163,6 +215,11 @@ namespace Amazon.Ion.ObjectMapper
         public SymbolToken Deserialize(IIonReader reader)
         {
             return reader.SymbolValue();
+        }
+        
+        public void Serialize(IIonWriter writer, SymbolToken item)
+        {
+            writer.WriteSymbolToken(item);
         }
 
         public void Serialize(IIonWriter writer, object item)
@@ -180,6 +237,11 @@ namespace Amazon.Ion.ObjectMapper
             return Encoding.UTF8.GetString(clob);
         }
 
+        public void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteClob(Encoding.UTF8.GetBytes(item));
+        }
+        
         public void Serialize(IIonWriter writer, object item)
         {
             writer.WriteClob(Encoding.UTF8.GetBytes(item as string));
@@ -203,12 +265,17 @@ namespace Amazon.Ion.ObjectMapper
             return new Guid(blob);
         }
 
-        public void Serialize(IIonWriter writer, object item)
+        public void Serialize(IIonWriter writer, Guid item)
         {
             if (annotateGuids) {
                 writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             }
-            writer.WriteBlob(((Guid)item).ToByteArray());
+            writer.WriteBlob(item.ToByteArray());
+        }
+        
+        public void Serialize(IIonWriter writer, object item)
+        {
+            this.Serialize(writer, (Guid)item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Generic; 
-using System.Numerics;
+using System.Collections.Generic;
 using System.Text;
 using Amazon.IonDotnet;
 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -243,67 +243,86 @@ namespace Amazon.Ion.ObjectMapper
 
         public object Deserialize(IIonReader reader, Type type, IonType ionType)
         {
-            dynamic serializer;
-            switch (ionType)
+            if (ionType == IonType.None || ionType == IonType.Null)
             {
-                case IonType.None:
-                case IonType.Null:
-                    serializer = this.nullSerializer;
-                    break;
-                case IonType.Bool:
-                    serializer = this.primitiveSerializers[typeof(bool)];
-                    break;
-                case IonType.Int when reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)):
-                    serializer = this.primitiveSerializers[typeof(long)];
-                    break;
-                case IonType.Int:
-                    serializer = this.primitiveSerializers[typeof(int)];
-                    break;
-                case IonType.Float when reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)):
-                    serializer = this.primitiveSerializers[typeof(float)];
-                    break;
-                case IonType.Float:
-                    serializer = this.primitiveSerializers[typeof(double)];
-                    break;
-                case IonType.Decimal when reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)):
-                    serializer = this.primitiveSerializers[typeof(decimal)];
-                    break;
-                case IonType.Decimal:
-                    serializer = this.primitiveSerializers[typeof(BigDecimal)];
-                    break;
-                case IonType.Blob when reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
-                                       || type.IsAssignableTo(typeof(Guid)):
-                    serializer = this.primitiveSerializers[typeof(Guid)];
-                    break;
-                case IonType.Blob:
-                    serializer = this.primitiveSerializers[typeof(byte[])];
-                    break;
-                case IonType.String:
-                    serializer = this.primitiveSerializers[typeof(string)];
-                    break;
-                case IonType.Symbol:
-                    serializer = this.primitiveSerializers[typeof(SymbolToken)];
-                    break;
-                case IonType.Timestamp:
-                    serializer = this.primitiveSerializers[typeof(DateTime)];
-                    break;
-                case IonType.Clob:
-                    serializer = this.clobSerializer;
-                    break;
-                case IonType.List:
-                    this.listSerializer.SetListType(type);
-                    serializer = this.listSerializer;
-                    break;
-                case IonType.Struct:
-                    this.objectSerializer.targetType = type;
-                    serializer = this.objectSerializer;
-                    break;
-                default:
-                    throw new NotSupportedException(
-                        $"Don't know how to Deserialize this Ion data. Last IonType was: {ionType}");
+                return this.nullSerializer.Deserialize(reader);
+            }
+
+            if (ionType == IonType.Bool)
+            {
+                return this.primitiveSerializers[typeof(bool)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Int)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
+                {
+                    return this.primitiveSerializers[typeof(long)].Deserialize(reader);
+                }
+                return this.primitiveSerializers[typeof(int)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Float)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
+                {
+                    return this.primitiveSerializers[typeof(float)].Deserialize(reader);
+                }
+                return this.primitiveSerializers[typeof(double)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Decimal)
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
+                {
+                    return this.primitiveSerializers[typeof(decimal)].Deserialize(reader);
+                }
+                return this.primitiveSerializers[typeof(BigDecimal)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Blob) 
+            {
+                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
+                    || type.IsAssignableTo(typeof(Guid)))
+                {
+                    return this.primitiveSerializers[typeof(Guid)].Deserialize(reader);
+                }
+                return this.primitiveSerializers[typeof(byte[])].Deserialize(reader);
+            }
+
+            if (ionType == IonType.String) 
+            {
+                return this.primitiveSerializers[typeof(string)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Symbol) 
+            {
+                return this.primitiveSerializers[typeof(SymbolToken)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Timestamp) 
+            {
+                return this.primitiveSerializers[typeof(DateTime)].Deserialize(reader);
+            }
+
+            if (ionType == IonType.Clob) 
+            {
+                return this.clobSerializer.Deserialize(reader);
+            }
+
+            if (ionType == IonType.List) 
+            {
+                this.listSerializer.SetListType(type);
+                return this.listSerializer.Deserialize(reader);
+            }
+
+            if (ionType == IonType.Struct) 
+            {
+                this.objectSerializer.targetType = type;
+                return this.objectSerializer.Deserialize(reader);
             }
             
-            return serializer.Deserialize(reader);
+            throw new NotSupportedException($"Data with Ion type {ionType} is not supported for deserialization");
         }
 
         public T Deserialize<T>(IIonReader reader)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -216,19 +216,21 @@ namespace Amazon.Ion.ObjectMapper
                 return;
             }
 
-            switch (item)
+            if (item is IList)
             {
-                case IList:
-                    this.listSerializer.SetListType(type);
-                    this.listSerializer.Serialize(writer, item);
-                    break;
-                case object:
-                    this.objectSerializer.targetType = type;
-                    this.objectSerializer.Serialize(writer, item);
-                    break;
-                default:
-                    throw new NotSupportedException($"Do not know how to serialize type {typeof(T)}");
+                this.listSerializer.SetListType(type);
+                this.listSerializer.Serialize(writer, item);
+                return;
             }
+            
+            if (item is object)
+            {
+                this.objectSerializer.targetType = type;
+                this.objectSerializer.Serialize(writer, item);
+                return;
+            }
+            
+            throw new NotSupportedException($"Do not know how to serialize type {typeof(T)}");
         }
 
         public T Deserialize<T>(Stream stream)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -142,10 +142,6 @@ namespace Amazon.Ion.ObjectMapper
     {
         internal readonly IonSerializationOptions options;
         private Dictionary<Type, dynamic> primitiveSerializers { get; init; }
-        private IonNullSerializer nullSerializer { get; init; }
-        private IonClobSerializer clobSerializer { get; init; }
-        private IonListSerializer listSerializer { get; init; }
-        private IonObjectSerializer objectSerializer { get; init; }
 
         public IonSerializer() : this(new IonSerializationOptions())
         {
@@ -167,12 +163,8 @@ namespace Amazon.Ion.ObjectMapper
                 {typeof(BigDecimal), new IonBigDecimalSerializer()},
                 {typeof(SymbolToken), new IonSymbolSerializer()},
                 {typeof(DateTime), new IonDateTimeSerializer()},
-                {typeof(Guid), new IonGuidSerializer(this.options.AnnotateGuids)},
+                {typeof(Guid), new IonGuidSerializer(this.options)},
             };
-            this.nullSerializer = new IonNullSerializer();
-            this.clobSerializer = new IonClobSerializer();
-            this.listSerializer = new IonListSerializer(this);
-            this.objectSerializer = new IonObjectSerializer(this);
 
             if (this.options.IonSerializers != null)
             {
@@ -210,7 +202,7 @@ namespace Amazon.Ion.ObjectMapper
         {
             if (item == null)
             {
-                this.nullSerializer.Serialize(writer, null);
+                new IonNullSerializer().Serialize(writer, null);
                 return;
             }
 
@@ -223,15 +215,13 @@ namespace Amazon.Ion.ObjectMapper
 
             if (item is IList)
             {
-                this.listSerializer.SetListType(type);
-                this.listSerializer.Serialize(writer, item);
+                new IonListSerializer(this, type).Serialize(writer, item);
                 return;
             }
             
             if (item is object)
             {
-                this.objectSerializer.targetType = type;
-                this.objectSerializer.Serialize(writer, item);
+                new IonObjectSerializer(this, options, type).Serialize(writer, item);
                 return;
             }
             
@@ -257,7 +247,7 @@ namespace Amazon.Ion.ObjectMapper
 
             if (ionType == IonType.None || ionType == IonType.Null)
             {
-                return this.nullSerializer.Deserialize(reader);
+                return new IonNullSerializer().Deserialize(reader);
             }
 
             if (ionType == IonType.Bool)
@@ -319,19 +309,17 @@ namespace Amazon.Ion.ObjectMapper
 
             if (ionType == IonType.Clob) 
             {
-                return this.clobSerializer.Deserialize(reader);
+                return new IonClobSerializer().Deserialize(reader);
             }
 
             if (ionType == IonType.List) 
             {
-                this.listSerializer.SetListType(type);
-                return this.listSerializer.Deserialize(reader);
+                return new IonListSerializer(this, type).Deserialize(reader);
             }
 
             if (ionType == IonType.Struct) 
             {
-                this.objectSerializer.targetType = type;
-                return this.objectSerializer.Deserialize(reader);
+                return new IonObjectSerializer(this, options, type).Deserialize(reader);
             }
 
             throw new NotSupportedException($"Data with Ion type {ionType} is not supported for deserialization");

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -321,7 +321,7 @@ namespace Amazon.Ion.ObjectMapper
                 this.objectSerializer.targetType = type;
                 return this.objectSerializer.Deserialize(reader);
             }
-            
+
             throw new NotSupportedException($"Data with Ion type {ionType} is not supported for deserialization");
         }
 
@@ -337,58 +337,82 @@ namespace Amazon.Ion.ObjectMapper
                 throw new NotSupportedException($"Custom serializer for {type} is not supported");
             }
             
-            if (type == typeof(bool)) return serializer is IonSerializer<bool>;
+            if (type == typeof(bool))
+                return serializer is IonSerializer<bool>;
 
-            if (type == typeof(string)) return serializer is IonSerializer<string>;
+            if (type == typeof(string))
+                return serializer is IonSerializer<string>;
 
-            if (type == typeof(byte[])) return serializer is IonSerializer<byte[]>;
+            if (type == typeof(byte[]))
+                return serializer is IonSerializer<byte[]>;
 
-            if (type == typeof(int)) return serializer is IonSerializer<int>;
+            if (type == typeof(int))
+                return serializer is IonSerializer<int>;
 
-            if (type == typeof(long)) return serializer is IonSerializer<long>;
+            if (type == typeof(long))
+                return serializer is IonSerializer<long>;
 
-            if (type == typeof(float)) return serializer is IonSerializer<float>;
+            if (type == typeof(float))
+                return serializer is IonSerializer<float>;
 
-            if (type == typeof(double)) return serializer is IonSerializer<double>;
+            if (type == typeof(double))
+                return serializer is IonSerializer<double>;
             
-            if (type == typeof(decimal)) return serializer is IonSerializer<decimal>;
+            if (type == typeof(decimal))
+                return serializer is IonSerializer<decimal>;
             
-            if (type == typeof(BigDecimal)) return serializer is IonSerializer<BigDecimal>;
+            if (type == typeof(BigDecimal))
+                return serializer is IonSerializer<BigDecimal>;
 
-            if (type == typeof(SymbolToken)) return serializer is IonSerializer<SymbolToken>;
+            if (type == typeof(SymbolToken))
+                return serializer is IonSerializer<SymbolToken>;
             
-            if (type == typeof(DateTime)) return serializer is IonSerializer<DateTime>;
+            if (type == typeof(DateTime))
+                return serializer is IonSerializer<DateTime>;
 
-            if (type == typeof(Guid)) return serializer is IonSerializer<Guid>;
+            if (type == typeof(Guid))
+                return serializer is IonSerializer<Guid>;
 
             return false;
         }
 
         private void SerializePrimitive(Type type, IIonWriter writer, object item)
         {
-            if (type == typeof(bool)) this.primitiveSerializers[type].Serialize(writer, Convert.ToBoolean(item));
+            if (type == typeof(bool))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToBoolean(item));
 
-            else if (type == typeof(string)) this.primitiveSerializers[type].Serialize(writer, item as string);
+            else if (type == typeof(string))
+                this.primitiveSerializers[type].Serialize(writer, item as string);
 
-            else if (type == typeof(byte[])) this.primitiveSerializers[type].Serialize(writer, (byte[])item);
+            else if (type == typeof(byte[]))
+                this.primitiveSerializers[type].Serialize(writer, (byte[])item);
 
-            else if (type == typeof(int)) this.primitiveSerializers[type].Serialize(writer, Convert.ToInt32(item));
+            else if (type == typeof(int))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToInt32(item));
 
-            else if (type == typeof(long)) this.primitiveSerializers[type].Serialize(writer, Convert.ToInt64(item));
+            else if (type == typeof(long))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToInt64(item));
 
-            else if (type == typeof(float)) this.primitiveSerializers[type].Serialize(writer, Convert.ToSingle(item));
+            else if (type == typeof(float))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToSingle(item));
 
-            else if (type == typeof(double)) this.primitiveSerializers[type].Serialize(writer, Convert.ToDouble(item));
+            else if (type == typeof(double))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToDouble(item));
             
-            else if (type == typeof(decimal)) this.primitiveSerializers[type].Serialize(writer, Convert.ToDecimal(item));
+            else if (type == typeof(decimal))
+                this.primitiveSerializers[type].Serialize(writer, Convert.ToDecimal(item));
             
-            else if (type == typeof(BigDecimal)) this.primitiveSerializers[type].Serialize(writer, (BigDecimal)item);
+            else if (type == typeof(BigDecimal))
+                this.primitiveSerializers[type].Serialize(writer, (BigDecimal)item);
 
-            else if (type == typeof(SymbolToken)) this.primitiveSerializers[type].Serialize(writer, (SymbolToken)item);
+            else if (type == typeof(SymbolToken))
+                this.primitiveSerializers[type].Serialize(writer, (SymbolToken)item);
             
-            else if (type == typeof(DateTime)) this.primitiveSerializers[type].Serialize(writer, (DateTime)item);
+            else if (type == typeof(DateTime))
+                this.primitiveSerializers[type].Serialize(writer, (DateTime)item);
 
-            else if (type == typeof(Guid)) this.primitiveSerializers[type].Serialize(writer, (Guid)item);
+            else if (type == typeof(Guid))
+                this.primitiveSerializers[type].Serialize(writer, (Guid)item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -215,7 +215,7 @@ namespace Amazon.Ion.ObjectMapper
 
             if (item is IList)
             {
-                new IonListSerializer(this, type).Serialize(writer, item);
+                new IonListSerializer(this, type).Serialize(writer, (IList)item);
                 return;
             }
             

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -265,7 +265,8 @@ namespace Amazon.Ion.ObjectMapper
                     this.objectSerializer.targetType = type;
                     return this.objectSerializer.Deserialize(reader);
                 default:
-                    throw new NotSupportedException("Don't know how to Deserialize this Ion data. Last IonType was: " + ionType);
+                    throw new NotSupportedException(
+                        $"Don't know how to Deserialize this Ion data. Last IonType was: {ionType}");
             }
         }
 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -343,42 +343,66 @@ namespace Amazon.Ion.ObjectMapper
             {
                 throw new NotSupportedException($"Custom serializer for {type} is not supported");
             }
-            
+
             if (type == typeof(bool))
+            {
                 return serializer is IonSerializer<bool>;
+            }
 
             if (type == typeof(string))
+            {
                 return serializer is IonSerializer<string>;
+            }
 
             if (type == typeof(byte[]))
+            {
                 return serializer is IonSerializer<byte[]>;
+            }
 
             if (type == typeof(int))
+            {
                 return serializer is IonSerializer<int>;
+            }
 
             if (type == typeof(long))
+            {
                 return serializer is IonSerializer<long>;
+            }
 
             if (type == typeof(float))
+            {
                 return serializer is IonSerializer<float>;
+            }
 
             if (type == typeof(double))
+            {
                 return serializer is IonSerializer<double>;
-            
+            }
+
             if (type == typeof(decimal))
+            {
                 return serializer is IonSerializer<decimal>;
-            
+            }
+
             if (type == typeof(BigDecimal))
+            {
                 return serializer is IonSerializer<BigDecimal>;
+            }
 
             if (type == typeof(SymbolToken))
+            {
                 return serializer is IonSerializer<SymbolToken>;
-            
+            }
+
             if (type == typeof(DateTime))
+            {
                 return serializer is IonSerializer<DateTime>;
+            }
 
             if (type == typeof(Guid))
+            {
                 return serializer is IonSerializer<Guid>;
+            }
 
             return false;
         }
@@ -386,42 +410,66 @@ namespace Amazon.Ion.ObjectMapper
         private void SerializePrimitive(Type type, IIonWriter writer, object item)
         {
             var serializer = this.primitiveSerializers[type];
-            
+
             if (type == typeof(bool))
+            {
                 serializer.Serialize(writer, Convert.ToBoolean(item));
+            }
 
             else if (type == typeof(string))
+            {
                 serializer.Serialize(writer, item as string);
+            }
 
             else if (type == typeof(byte[]))
+            {
                 serializer.Serialize(writer, (byte[])item);
+            }
 
             else if (type == typeof(int))
+            {
                 serializer.Serialize(writer, Convert.ToInt32(item));
+            }
 
             else if (type == typeof(long))
+            {
                 serializer.Serialize(writer, Convert.ToInt64(item));
+            }
 
             else if (type == typeof(float))
+            {
                 serializer.Serialize(writer, Convert.ToSingle(item));
+            }
 
             else if (type == typeof(double))
+            {
                 serializer.Serialize(writer, Convert.ToDouble(item));
-            
+            }
+
             else if (type == typeof(decimal))
+            {
                 serializer.Serialize(writer, Convert.ToDecimal(item));
-            
+            }
+
             else if (type == typeof(BigDecimal))
+            {
                 serializer.Serialize(writer, (BigDecimal)item);
+            }
 
             else if (type == typeof(SymbolToken))
+            {
                 serializer.Serialize(writer, (SymbolToken)item);
-            
+            }
+
             else if (type == typeof(DateTime))
+            {
                 serializer.Serialize(writer, (DateTime)item);
+            }
 
             else if (type == typeof(Guid))
+            {
                 serializer.Serialize(writer, (Guid)item);
+            }
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -248,34 +248,34 @@ namespace Amazon.Ion.ObjectMapper
 
             if (ionType == IonType.Bool)
             {
-                return this.primitiveSerializers[typeof(bool)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(bool)).Deserialize(reader);
             }
 
             if (ionType == IonType.Int)
             {
                 if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
                 {
-                    return this.primitiveSerializers[typeof(long)].Deserialize(reader);
+                    return this.GetPrimitiveSerializer(typeof(long)).Deserialize(reader);
                 }
-                return this.primitiveSerializers[typeof(int)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(int)).Deserialize(reader);
             }
 
             if (ionType == IonType.Float)
             {
                 if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
                 {
-                    return this.primitiveSerializers[typeof(float)].Deserialize(reader);
+                    return this.GetPrimitiveSerializer(typeof(float)).Deserialize(reader);
                 }
-                return this.primitiveSerializers[typeof(double)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(double)).Deserialize(reader);
             }
 
             if (ionType == IonType.Decimal)
             {
                 if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
                 {
-                    return this.primitiveSerializers[typeof(decimal)].Deserialize(reader);
+                    return this.GetPrimitiveSerializer(typeof(decimal)).Deserialize(reader);
                 }
-                return this.primitiveSerializers[typeof(BigDecimal)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(BigDecimal)).Deserialize(reader);
             }
 
             if (ionType == IonType.Blob) 
@@ -283,24 +283,24 @@ namespace Amazon.Ion.ObjectMapper
                 if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
                     || type.IsAssignableTo(typeof(Guid)))
                 {
-                    return this.primitiveSerializers[typeof(Guid)].Deserialize(reader);
+                    return this.GetPrimitiveSerializer(typeof(Guid)).Deserialize(reader);
                 }
-                return this.primitiveSerializers[typeof(byte[])].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(byte[])).Deserialize(reader);
             }
 
             if (ionType == IonType.String) 
             {
-                return this.primitiveSerializers[typeof(string)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(string)).Deserialize(reader);
             }
 
             if (ionType == IonType.Symbol) 
             {
-                return this.primitiveSerializers[typeof(SymbolToken)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(SymbolToken)).Deserialize(reader);
             }
 
             if (ionType == IonType.Timestamp) 
             {
-                return this.primitiveSerializers[typeof(DateTime)].Deserialize(reader);
+                return this.GetPrimitiveSerializer(typeof(DateTime)).Deserialize(reader);
             }
 
             if (ionType == IonType.Clob) 
@@ -332,85 +332,143 @@ namespace Amazon.Ion.ObjectMapper
             {
                 throw new NotSupportedException($"Custom serializer for {type} is not supported");
             }
-            
+
             if (type == typeof(bool))
+            {
                 return serializer is IonSerializer<bool>;
+            }
 
             if (type == typeof(string))
+            {
                 return serializer is IonSerializer<string>;
+            }
 
             if (type == typeof(byte[]))
+            {
                 return serializer is IonSerializer<byte[]>;
+            }
 
             if (type == typeof(int))
+            {
                 return serializer is IonSerializer<int>;
+            }
 
             if (type == typeof(long))
+            {
                 return serializer is IonSerializer<long>;
+            }
 
             if (type == typeof(float))
+            {
                 return serializer is IonSerializer<float>;
+            }
 
             if (type == typeof(double))
+            {
                 return serializer is IonSerializer<double>;
-            
+            }
+
             if (type == typeof(decimal))
+            {
                 return serializer is IonSerializer<decimal>;
-            
+            }
+
             if (type == typeof(BigDecimal))
+            {
                 return serializer is IonSerializer<BigDecimal>;
+            }
 
             if (type == typeof(SymbolToken))
+            {
                 return serializer is IonSerializer<SymbolToken>;
-            
+            }
+
             if (type == typeof(DateTime))
+            {
                 return serializer is IonSerializer<DateTime>;
+            }
 
             if (type == typeof(Guid))
+            {
                 return serializer is IonSerializer<Guid>;
+            }
 
             return false;
         }
 
         private void SerializePrimitive(Type type, IIonWriter writer, object item)
         {
-            var serializer = this.primitiveSerializers[type];
-            
+            var serializer = this.GetPrimitiveSerializer(type);
+
             if (type == typeof(bool))
+            {
                 serializer.Serialize(writer, Convert.ToBoolean(item));
+            }
 
             else if (type == typeof(string))
+            {
                 serializer.Serialize(writer, item as string);
+            }
 
             else if (type == typeof(byte[]))
-                serializer.Serialize(writer, (byte[])item);
+            {
+                serializer.Serialize(writer, (byte[]) item);
+            }
 
             else if (type == typeof(int))
+            {
                 serializer.Serialize(writer, Convert.ToInt32(item));
+            }
 
             else if (type == typeof(long))
+            {
                 serializer.Serialize(writer, Convert.ToInt64(item));
+            }
 
             else if (type == typeof(float))
+            {
                 serializer.Serialize(writer, Convert.ToSingle(item));
+            }
 
             else if (type == typeof(double))
+            {
                 serializer.Serialize(writer, Convert.ToDouble(item));
-            
+            }
+
             else if (type == typeof(decimal))
+            {
                 serializer.Serialize(writer, Convert.ToDecimal(item));
-            
+            }
+
             else if (type == typeof(BigDecimal))
-                serializer.Serialize(writer, (BigDecimal)item);
+            {
+                serializer.Serialize(writer, (BigDecimal) item);
+            }
 
             else if (type == typeof(SymbolToken))
-                serializer.Serialize(writer, (SymbolToken)item);
-            
+            {
+                serializer.Serialize(writer, (SymbolToken) item);
+            }
+
             else if (type == typeof(DateTime))
-                serializer.Serialize(writer, (DateTime)item);
+            {
+                serializer.Serialize(writer, (DateTime) item);
+            }
 
             else if (type == typeof(Guid))
-                serializer.Serialize(writer, (Guid)item);
+            {
+                serializer.Serialize(writer, (Guid) item);
+            }
+        }
+
+        private dynamic GetPrimitiveSerializer(Type type)
+        {
+            if (this.options.IonSerializers != null && this.options.IonSerializers.ContainsKey(type))
+            {
+                return this.options.IonSerializers[type];
+            }
+
+            return this.primitiveSerializers[type];
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -11,7 +11,7 @@ namespace Amazon.Ion.ObjectMapper
 {
     public interface IonSerializer<T>
     {
-        void Serialize(IIonWriter writer, object item);
+        void Serialize(IIonWriter writer, T item);
         T Deserialize(IIonReader reader);
     }
 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -163,7 +163,7 @@ namespace Amazon.Ion.ObjectMapper
                 {typeof(BigDecimal), new IonBigDecimalSerializer()},
                 {typeof(SymbolToken), new IonSymbolSerializer()},
                 {typeof(DateTime), new IonDateTimeSerializer()},
-                {typeof(Guid), new IonGuidSerializer(this.options.AnnotateGuids)},
+                {typeof(Guid), new IonGuidSerializer(this.options)},
             };
 
             if (this.options.IonSerializers != null)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -110,7 +110,7 @@ namespace Amazon.Ion.ObjectMapper
         public bool IgnoreReadOnlyFields { get; init; } = false;
         public readonly bool IgnoreReadOnlyProperties;
         public readonly bool PropertyNameCaseInsensitive;
-        public readonly bool IgnoreDefaults;
+        public bool IgnoreDefaults { get; init; } = false;
         public bool IncludeTypeInformation { get; init; } = false;
         public TypeAnnotationPrefix TypeAnnotationPrefix { get; init; } = new NamespaceTypeAnnotationPrefix();
         public TypeAnnotator TypeAnnotator { get; init; } = new DefaultTypeAnnotator();

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -226,48 +226,67 @@ namespace Amazon.Ion.ObjectMapper
 
         public object Deserialize(IIonReader reader, Type type, IonType ionType)
         {
+            dynamic serializer;
             switch (ionType)
             {
                 case IonType.None:
                 case IonType.Null:
-                    return this.nullSerializer.Deserialize(reader);
+                    serializer = this.nullSerializer;
+                    break;
                 case IonType.Bool:
-                    return this.primitiveSerializers[typeof(bool)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(bool)];
+                    break;
                 case IonType.Int when reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)):
-                    return this.primitiveSerializers[typeof(long)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(long)];
+                    break;
                 case IonType.Int:
-                    return this.primitiveSerializers[typeof(int)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(int)];
+                    break;
                 case IonType.Float when reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)):
-                    return this.primitiveSerializers[typeof(float)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(float)];
+                    break;
                 case IonType.Float:
-                    return this.primitiveSerializers[typeof(double)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(double)];
+                    break;
                 case IonType.Decimal when reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)):
-                    return this.primitiveSerializers[typeof(decimal)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(decimal)];
+                    break;
                 case IonType.Decimal:
-                    return this.primitiveSerializers[typeof(BigDecimal)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(BigDecimal)];
+                    break;
                 case IonType.Blob when reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
                                        || type.IsAssignableTo(typeof(Guid)):
-                    return this.primitiveSerializers[typeof(Guid)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(Guid)];
+                    break;
                 case IonType.Blob:
-                    return this.primitiveSerializers[typeof(byte[])].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(byte[])];
+                    break;
                 case IonType.String:
-                    return this.primitiveSerializers[typeof(string)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(string)];
+                    break;
                 case IonType.Symbol:
-                    return this.primitiveSerializers[typeof(SymbolToken)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(SymbolToken)];
+                    break;
                 case IonType.Timestamp:
-                    return this.primitiveSerializers[typeof(DateTime)].Deserialize(reader);
+                    serializer = this.primitiveSerializers[typeof(DateTime)];
+                    break;
                 case IonType.Clob:
-                    return this.clobSerializer.Deserialize(reader);
+                    serializer = this.clobSerializer;
+                    break;
                 case IonType.List:
                     this.listSerializer.SetListType(type);
-                    return this.listSerializer.Deserialize(reader);
+                    serializer = this.listSerializer;
+                    break;
                 case IonType.Struct:
                     this.objectSerializer.targetType = type;
-                    return this.objectSerializer.Deserialize(reader);
+                    serializer = this.objectSerializer;
+                    break;
                 default:
                     throw new NotSupportedException(
                         $"Don't know how to Deserialize this Ion data. Last IonType was: {ionType}");
             }
+            
+            return serializer.Deserialize(reader);
         }
 
         public T Deserialize<T>(IIonReader reader)

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -378,41 +378,43 @@ namespace Amazon.Ion.ObjectMapper
 
         private void SerializePrimitive(Type type, IIonWriter writer, object item)
         {
+            var serializer = this.primitiveSerializers[type];
+            
             if (type == typeof(bool))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToBoolean(item));
+                serializer.Serialize(writer, Convert.ToBoolean(item));
 
             else if (type == typeof(string))
-                this.primitiveSerializers[type].Serialize(writer, item as string);
+                serializer.Serialize(writer, item as string);
 
             else if (type == typeof(byte[]))
-                this.primitiveSerializers[type].Serialize(writer, (byte[])item);
+                serializer.Serialize(writer, (byte[])item);
 
             else if (type == typeof(int))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToInt32(item));
+                serializer.Serialize(writer, Convert.ToInt32(item));
 
             else if (type == typeof(long))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToInt64(item));
+                serializer.Serialize(writer, Convert.ToInt64(item));
 
             else if (type == typeof(float))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToSingle(item));
+                serializer.Serialize(writer, Convert.ToSingle(item));
 
             else if (type == typeof(double))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToDouble(item));
+                serializer.Serialize(writer, Convert.ToDouble(item));
             
             else if (type == typeof(decimal))
-                this.primitiveSerializers[type].Serialize(writer, Convert.ToDecimal(item));
+                serializer.Serialize(writer, Convert.ToDecimal(item));
             
             else if (type == typeof(BigDecimal))
-                this.primitiveSerializers[type].Serialize(writer, (BigDecimal)item);
+                serializer.Serialize(writer, (BigDecimal)item);
 
             else if (type == typeof(SymbolToken))
-                this.primitiveSerializers[type].Serialize(writer, (SymbolToken)item);
+                serializer.Serialize(writer, (SymbolToken)item);
             
             else if (type == typeof(DateTime))
-                this.primitiveSerializers[type].Serialize(writer, (DateTime)item);
+                serializer.Serialize(writer, (DateTime)item);
 
             else if (type == typeof(Guid))
-                this.primitiveSerializers[type].Serialize(writer, (Guid)item);
+                serializer.Serialize(writer, (Guid)item);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -140,7 +140,7 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonSerializer
     {
-        internal readonly IonSerializationOptions options;
+        private readonly IonSerializationOptions options;
         private Dictionary<Type, dynamic> primitiveSerializers { get; init; }
 
         public IonSerializer() : this(new IonSerializationOptions())
@@ -170,11 +170,7 @@ namespace Amazon.Ion.ObjectMapper
             {
                 foreach (var serializer in this.options.IonSerializers)
                 {
-                    if (ValidateCustomSerializer(serializer.Key, serializer.Value))
-                    {
-                        this.primitiveSerializers[serializer.Key] = serializer.Value;
-                    }
-                    else
+                    if (!ValidateCustomSerializer(serializer.Key, serializer.Value))
                     {
                         throw new NotSupportedException($"Custom serializer does not satisfy IonSerializer<{serializer.Key}> interface");
                     }


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/14.

IonSerializers: `Dictionary<Type, IonSerializer>`

A Dictionary of IonSerializers which specifies, for a key Type, a custom Ion serializer for that type.

We will provide extension points to allow for arbitrarily fine-grained control over the serialization process. There are a few ways to specify this. To the IonSerializer, one can pass in options including a Dictionary of Type onto IonSerializer. This mapping will take precedence over the default mapping.

```c#
new IonSerializer(new IonSerializationOptions
{
     IonSerializers = new Dictionary<Type, IonSerializer>()
    {
        {typeof(string), new MyCustomStringIonSerializer()},
        {typeof(DateTime), new MyCustomDateTimeIonSerializer()}
    },
});
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
