### PR TITLE
Deserialize annotations

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.IonDotnet;
+using Amazon.IonDotnet.Builders;
 using Amazon.IonDotnet.Tree;
+using Amazon.IonDotnet.Tree.Impl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Amazon.Ion.ObjectMapper.Test.Utils;
 
@@ -12,6 +14,8 @@ namespace Amazon.Ion.ObjectMapper.Test
     public class IonObjectSerializerTest
     {
         IonSerializer defaultSerializer = new IonSerializer();
+        private IValueFactory valueFactory = new ValueFactory();
+
         [TestMethod]
         public void SerializesAndDeserializesObjects()
         {
@@ -555,7 +559,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
-        public void DeserializeMultipleAnnotatedIonToClassNameWithAnnotated()
+        public void DeserializeMultipleAnnotatedIonToClassNameWithFirstAnnotated()
         {
             // Multiple annotations are ignored, it will only pick the first one.
             IIonValue ionTruck = valueFactory.NewEmptyStruct();
@@ -564,9 +568,24 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonReader reader = IonReaderBuilder.Build(ionTruck);
 
-            Truck truck = defaultSerializer.Deserialize<Truck>(reader);
+            Vehicle truck = defaultSerializer.Deserialize<Vehicle>(reader);
 
             AssertIsTruck(truck);
+        }
+
+        [TestMethod]
+        public void DeserializeMultipleAnnotatedIonToClassNameWithSecondAnnotated()
+        {
+            // Multiple annotations are ignored, it will only pick the first one.
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("FirstAnnotation");
+            ionTruck.AddTypeAnnotation("Truck");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            Vehicle truck = defaultSerializer.Deserialize<Vehicle>(reader);
+
+            Assert.AreNotEqual(TestObjects.nativeTruck.ToString(), truck.ToString());
         }
 
         private void AssertIsTruck(object actual)

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -486,5 +486,85 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.AreEqual(-TestObjects.honda.Weight, deserialized.Weight);
             Assert.AreEqual(TestObjects.honda.Engine.ManufactureDate.AddDays(1), deserialized.Engine.ManufactureDate);
         }
+
+        [TestMethod]
+        public void DeserializeAnnotatedIonToParentClassNameMatchingAnnotation()
+        {
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("Truck");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            IonSerializer ionSerializer = new IonSerializer();
+            Vehicle truck = ionSerializer.Deserialize<Vehicle>(reader);
+
+            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+        }
+
+        [TestMethod]
+        public void DeserializeAnnotatedIonToClassNameMatchingAnnotation()
+        {
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("Truck");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            IonSerializer ionSerializer = new IonSerializer();
+            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+
+            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+        }
+
+        [TestMethod]
+        public void DeserializeAnnotatedIonToClassNameNotMatchingAnnotation()
+        {
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("NonMatching");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            IonSerializer ionSerializer = new IonSerializer();
+            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+
+            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+        }
+
+        [TestMethod]
+        public void DeserializeAnnotatedIonToClassNameWithAnnotatedTypeAssemblies()
+        {
+            IonSerializationOptions options = new IonSerializationOptions
+            {
+                AnnotatedTypeAssemblies = new string[]
+                {
+                        typeof(Truck).Assembly.GetName().Name
+                }
+            };
+
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("Truck");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            IonSerializer ionSerializer = new IonSerializer(options);
+            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+
+            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+        }
+
+        [TestMethod]
+        public void DeserializeMultipleAnnotatedIonToClassNameWithAnnotated()
+        {
+            // Multiple annotations are ignored, it will only pick the first one.
+            IIonValue ionTruck = valueFactory.NewEmptyStruct();
+            ionTruck.AddTypeAnnotation("Truck");
+            ionTruck.AddTypeAnnotation("SecondAnnotation");
+
+            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+            IonSerializer ionSerializer = new IonSerializer();
+            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+
+            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+        }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -11,6 +11,7 @@ namespace Amazon.Ion.ObjectMapper.Test
     [TestClass]
     public class IonObjectSerializerTest
     {
+        IonSerializer defaultSerializer = new IonSerializer();
         [TestMethod]
         public void SerializesAndDeserializesObjects()
         {
@@ -490,27 +491,21 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeAnnotatedIonToParentClassNameMatchingAnnotation()
         {
-            string truckIonText = "Truck:: { }";
+            IIonReader reader = IonReaderBuilder.Build(TestObjects.truckIonText);
 
-            IIonReader reader = IonReaderBuilder.Build(truckIonText);
+            Vehicle truck = defaultSerializer.Deserialize<Vehicle>(reader);
 
-            IonSerializer ionSerializer = new IonSerializer();
-            Vehicle truck = ionSerializer.Deserialize<Vehicle>(reader);
-
-            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+            AssertIsTruck(truck);
         }
 
         [TestMethod]
         public void DeserializeAnnotatedIonToClassNameMatchingAnnotation()
         {
-            string truckIonText = "Truck:: { }";
+            IIonReader reader = IonReaderBuilder.Build(TestObjects.truckIonText);
 
-            IIonReader reader = IonReaderBuilder.Build(truckIonText);
+            Truck truck = defaultSerializer.Deserialize<Truck>(reader);
 
-            IonSerializer ionSerializer = new IonSerializer();
-            Truck truck = ionSerializer.Deserialize<Truck>(reader);
-
-            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+            AssertIsTruck(truck);
         }
 
         [TestMethod]
@@ -520,10 +515,9 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonReader reader = IonReaderBuilder.Build(annotatedIonText);
 
-            IonSerializer ionSerializer = new IonSerializer();
-            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+            Truck truck = defaultSerializer.Deserialize<Truck>(reader);
 
-            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+            AssertIsTruck(truck);
         }
 
         [TestMethod]
@@ -537,14 +531,27 @@ namespace Amazon.Ion.ObjectMapper.Test
                 }
             };
 
-            string truckIonText = "Truck:: { }";
-
-            IIonReader reader = IonReaderBuilder.Build(truckIonText);
+            IIonReader reader = IonReaderBuilder.Build(TestObjects.truckIonText);
 
             IonSerializer ionSerializer = new IonSerializer(options);
-            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+            Vehicle truck = ionSerializer.Deserialize<Vehicle>(reader);
 
-            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+            AssertIsTruck(truck);
+
+            // Ensure default loaded assemblies are not searched in if annotated type assemblies are given
+            options = new IonSerializationOptions
+            {
+                AnnotatedTypeAssemblies = new string[]
+                {
+                    "mockAssemblyName"
+                }
+            };
+
+            reader = IonReaderBuilder.Build(TestObjects.truckIonText);
+            ionSerializer = new IonSerializer(options);
+            truck = ionSerializer.Deserialize<Vehicle>(reader);
+
+            Assert.AreNotEqual(TestObjects.nativeTruck.ToString(), truck.ToString());
         }
 
         [TestMethod]
@@ -557,10 +564,14 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             IIonReader reader = IonReaderBuilder.Build(ionTruck);
 
-            IonSerializer ionSerializer = new IonSerializer();
-            Truck truck = ionSerializer.Deserialize<Truck>(reader);
+            Truck truck = defaultSerializer.Deserialize<Truck>(reader);
 
-            Assert.AreEqual(truck.ToString(), TestObjects.nativeTruck.ToString());
+            AssertIsTruck(truck);
+        }
+
+        private void AssertIsTruck(object actual)
+        {
+            Assert.AreEqual(actual.ToString(), TestObjects.nativeTruck.ToString());
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -490,10 +490,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeAnnotatedIonToParentClassNameMatchingAnnotation()
         {
-            IIonValue ionTruck = valueFactory.NewEmptyStruct();
-            ionTruck.AddTypeAnnotation("Truck");
+            string truckIonText = "Truck:: { }";
 
-            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+            IIonReader reader = IonReaderBuilder.Build(truckIonText);
 
             IonSerializer ionSerializer = new IonSerializer();
             Vehicle truck = ionSerializer.Deserialize<Vehicle>(reader);
@@ -504,10 +503,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeAnnotatedIonToClassNameMatchingAnnotation()
         {
-            IIonValue ionTruck = valueFactory.NewEmptyStruct();
-            ionTruck.AddTypeAnnotation("Truck");
+            string truckIonText = "Truck:: { }";
 
-            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+            IIonReader reader = IonReaderBuilder.Build(truckIonText);
 
             IonSerializer ionSerializer = new IonSerializer();
             Truck truck = ionSerializer.Deserialize<Truck>(reader);
@@ -518,10 +516,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeAnnotatedIonToClassNameNotMatchingAnnotation()
         {
-            IIonValue ionTruck = valueFactory.NewEmptyStruct();
-            ionTruck.AddTypeAnnotation("NonMatching");
+            string annotatedIonText = "NonMatching:: { }";
 
-            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+            IIonReader reader = IonReaderBuilder.Build(annotatedIonText);
 
             IonSerializer ionSerializer = new IonSerializer();
             Truck truck = ionSerializer.Deserialize<Truck>(reader);
@@ -540,10 +537,9 @@ namespace Amazon.Ion.ObjectMapper.Test
                 }
             };
 
-            IIonValue ionTruck = valueFactory.NewEmptyStruct();
-            ionTruck.AddTypeAnnotation("Truck");
+            string truckIonText = "Truck:: { }";
 
-            IIonReader reader = IonReaderBuilder.Build(ionTruck);
+            IIonReader reader = IonReaderBuilder.Build(truckIonText);
 
             IonSerializer ionSerializer = new IonSerializer(options);
             Truck truck = ionSerializer.Deserialize<Truck>(reader);

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -6,9 +6,12 @@ namespace Amazon.Ion.ObjectMapper.Test
 {
 
     [IonAnnotateType]
-    public abstract class Vehicle
+    public class Vehicle
     {
-
+        public override string ToString()
+        {
+            return "<Vehicle>";
+        }
     }
 
     [IonAnnotateType(Prefix = "my.universal.namespace", Name="BussyMcBusface")] 
@@ -143,6 +146,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         };
 
         public static Truck nativeTruck = new Truck();
+
+        public static string truckIonText = "Truck:: { }";
 
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -142,6 +142,8 @@ namespace Amazon.Ion.ObjectMapper.Test
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
+        public static Truck nativeTruck = new Truck();
+
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 
         public static Radio fmRadio = new Radio { Band = "FM" };

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Amazon.IonDotnet;
 using Amazon.IonDotnet.Builders;
 using static Amazon.Ion.ObjectMapper.IonSerializationFormat;
@@ -107,15 +106,16 @@ namespace Amazon.Ion.ObjectMapper
                 Type typeToCreate = null;
                 try
                 {
+                    // First throws InvalidOperationException if no elements match the condition
                     var assemblyName = options.AnnotatedTypeAssemblies.First(a => Type.GetType(FullName(typeName, a)) != null);
                     typeToCreate = Type.GetType(FullName(typeName, assemblyName));
                 }
-                catch
+                catch (InvalidOperationException)
                 {
                     typeToCreate = AppDomain.CurrentDomain
                         .GetAssemblies()
                         .SelectMany(x => x.GetTypes())
-                        .FirstOrDefault(t => string.Equals(t.Name, typeName, StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(type => string.Equals(type.Name, typeName, StringComparison.OrdinalIgnoreCase));
                 }
 
                 if (typeToCreate != null && targetType.IsAssignableFrom(typeToCreate))

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -104,13 +104,15 @@ namespace Amazon.Ion.ObjectMapper
             {
                 var typeName = annotations[0];
                 Type typeToCreate = null;
-                try
+
+                foreach (string assemblyName in options.AnnotatedTypeAssemblies)
                 {
-                    // First throws InvalidOperationException if no elements match the condition
-                    var assemblyName = options.AnnotatedTypeAssemblies.First(a => Type.GetType(FullName(typeName, a)) != null);
-                    typeToCreate = Type.GetType(FullName(typeName, assemblyName));
+                    if ((typeToCreate = Type.GetType(FullName(typeName, assemblyName))) != null) {
+                        break;
+                    }
                 }
-                catch (InvalidOperationException)
+
+                if (typeToCreate == null && options.AnnotatedTypeAssemblies.Length == 0)
                 {
                     typeToCreate = AppDomain.CurrentDomain
                         .GetAssemblies()
@@ -128,7 +130,7 @@ namespace Amazon.Ion.ObjectMapper
 
         private string FullName(string typeName, string assemblyName)
         {
-            return typeName + ", " + assemblyName;
+            return assemblyName + "." + typeName + "," + assemblyName;
         }
     }
 

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -105,14 +105,17 @@ namespace Amazon.Ion.ObjectMapper
                 var typeName = annotations[0];
                 Type typeToCreate = null;
 
-                foreach (string assemblyName in options.AnnotatedTypeAssemblies)
+                if (options.AnnotatedTypeAssemblies != null)
                 {
-                    if ((typeToCreate = Type.GetType(FullName(typeName, assemblyName))) != null) {
-                        break;
+                    foreach (string assemblyName in options.AnnotatedTypeAssemblies)
+                    {
+                        if ((typeToCreate = Type.GetType(FullName(typeName, assemblyName))) != null)
+                        {
+                            break;
+                        }
                     }
                 }
-
-                if (typeToCreate == null && options.AnnotatedTypeAssemblies.Length == 0)
+                else
                 {
                     typeToCreate = AppDomain.CurrentDomain
                         .GetAssemblies()
@@ -160,7 +163,7 @@ namespace Amazon.Ion.ObjectMapper
         public IonWriterFactory WriterFactory { get; init; } = new DefaultIonWriterFactory();
 
         public ObjectFactory ObjectFactory { get; init; } = new DefaultObjectFactory();
-        public string[] AnnotatedTypeAssemblies { get; init; } = new string[] {};
+        public IEnumerable<string> AnnotatedTypeAssemblies { get; init; }
 
         public readonly bool PermissiveMode;
         

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Amazon.IonDotnet;
 using Amazon.IonDotnet.Builders;
 using static Amazon.Ion.ObjectMapper.IonSerializationFormat;
@@ -117,10 +118,14 @@ namespace Amazon.Ion.ObjectMapper
                 }
                 else
                 {
-                    typeToCreate = AppDomain.CurrentDomain
-                        .GetAssemblies()
-                        .SelectMany(x => x.GetTypes())
-                        .FirstOrDefault(type => string.Equals(type.Name, typeName, StringComparison.OrdinalIgnoreCase));
+                    foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        typeToCreate = assembly.GetType(assembly.GetName().Name + "." + typeName);
+                        if (typeToCreate != null)
+                        {
+                            break;
+                        }
+                    }
                 }
 
                 if (typeToCreate != null && targetType.IsAssignableFrom(typeToCreate))

--- a/SPEC.md
+++ b/SPEC.md
@@ -185,6 +185,48 @@ public class Engine
 
 the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document.
 
+### Default behavior when deserializing annotated Ion
+
+Annotated Ion types will by default map to the C# class name in currently loaded assemblies if and only if the **first** type annotation matches the name of the class. The C# class type must also be a subtype of the type passed into the deserialize method.
+
+```c#
+public class DefaultDeserialization
+{
+    public class Car
+    {
+        public override string ToString()
+        {
+            return "<Car>";
+        }
+    }
+    
+    public class Truck : Car
+    {
+        public override string ToString()
+        {
+            return "<Truck>";
+        }
+    }
+    
+    public void DeserializeExample() {
+        // Create Ion strcut with annotation that matches Truck Class Type name.
+        IIonValue ionTruck = valueFactory.NewEmptyStruct();
+        ionTruck.AddTypeAnnotation("Truck");
+
+        IIonReader reader = IonReaderBuilder.Build(ionTruck);
+
+        IonSerializer ionSerializer = new IonSerializer();
+        // This will only attempt to deserialize into a Truck if and only if Truck is a subtype of the input Type, in this case Typeof(car).
+        var car = ionSerializer.Deserialize(reader, Typeof(Car));
+
+        // This will print "<Truck>".
+        string output = car.ToString();
+    }
+}
+```
+
+
+
 ### Supported types
 
 In addition to all `object` types these types are supported by default:

--- a/SPEC.md
+++ b/SPEC.md
@@ -209,11 +209,11 @@ public class DefaultDeserialization
     }
     
     public void DeserializeExample() {
-        // Create Ion strcut with annotation that matches Truck Class Type name.
-        IIonValue ionTruck = valueFactory.NewEmptyStruct();
-        ionTruck.AddTypeAnnotation("Truck");
+        // Create Ion struct with annotation that matches Truck Class Type name.
+        
+        string truckIonText = "Truck:: { }";
 
-        IIonReader reader = IonReaderBuilder.Build(ionTruck);
+        IIonReader reader = IonReaderBuilder.Build(truckIonText);
 
         IonSerializer ionSerializer = new IonSerializer();
         // This will only attempt to deserialize into a Truck if and only if Truck is a subtype of the input Type, in this case Typeof(car).


### PR DESCRIPTION
Changed the default behaivour when deserializing ion with annotations.

Before:
* If an ion has an annotation, we try to find a matching class name to the annotation if a list of namespaces and assemblies was provided. We ignore the type passed into deserialize, and can possibly create a null type without any warning to the user.

After:
* If an ion has an annotation, we first search for a matching class name to the annotation using an optionally given list of namespaces and assemblies. If one is not given, we look in the currently loaded assemblies for a matching class name. If no matching class name was found in the aforementioned cases, or if the type of the matching class name is not a subtype of the passed in type, we attempt to deserialize into the passed in type instead.