### PR TITLE
Add permissive mode (WIP)

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using Amazon.IonDotnet;
-using Amazon.IonDotnet.Builders;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Amazon.Ion.ObjectMapper.Test.Utils;
 

--- a/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using Amazon.IonDotnet;
+using Amazon.IonDotnet.Builders;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Amazon.Ion.ObjectMapper.Test.Utils;
 
@@ -33,7 +36,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeListToNonListWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOn.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
 
             var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
             Assert.IsNull(deserialized);
@@ -51,7 +54,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeNonGenericListsToNonListWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOn.Serialize(new ArrayList() { 1, "two", 3.14d });
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
 
             var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
             Assert.IsNull(deserialized);
@@ -69,7 +72,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeArrayToNonArrayWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOn.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
 
             var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
             Assert.IsNull(deserialized);
@@ -82,6 +85,42 @@ namespace Amazon.Ion.ObjectMapper.Test
             var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
 
             serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidCastException))]
+        public void DeserializeNonGenericListToArrayWithPermissiveModeOff()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            serializerWithPermissiveModeOff.Deserialize<int[]>(stream);
+        }
+
+        [TestMethod]
+        public void DeserializeNonGenericListToArrayWithPermissiveModeOn()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            var deserialized = serializerWithPermissiveModeOn.Deserialize<int[]>(stream);
+            Assert.AreEqual(new int[] { 1, 0, 0 }.ToString(), deserialized.ToString());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void DeserializeNonGenericListToGenericListWithPermissiveModeOff()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            serializerWithPermissiveModeOff.Deserialize<List<int>>(stream);
+        }
+
+        [TestMethod]
+        public void DeserializeNonGenericListToGenericListWithPermissiveModeOn()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            var deserialized = serializerWithPermissiveModeOn.Deserialize<List<int>>(stream);
+            Assert.AreEqual(new List<int>() { 1, 0, 0 }.ToString(), deserialized.ToString());
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
@@ -9,6 +9,9 @@ namespace Amazon.Ion.ObjectMapper.Test
     [TestClass]
     public class IonListSerializerTest
     {
+        IonSerializer serializerWithPermissiveModeOn = new IonSerializer(new IonSerializationOptions { PermissiveMode = true });
+        IonSerializer serializerWithPermissiveModeOff = new IonSerializer(new IonSerializationOptions { PermissiveMode = false });
+
         [TestMethod]
         public void SerializesAndDeserializesLists()
         {
@@ -25,6 +28,60 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void SerializesAndDeserializesArrays()
         {
             Check(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+        }
+
+        [TestMethod]
+        public void DeserializeListToNonListWithPermissiveModeOn()
+        {
+            var stream = serializerWithPermissiveModeOn.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+
+            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
+            Assert.IsNull(deserialized);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void DeserializeListToNonListWithPermissiveModeOff()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+
+            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+        }
+
+        [TestMethod]
+        public void DeserializeNonGenericListsToNonListWithPermissiveModeOn()
+        {
+            var stream = serializerWithPermissiveModeOn.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
+            Assert.IsNull(deserialized);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void DeserializeNonGenericListsToNonListWithPermissiveModeOff()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
+
+            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+        }
+
+        [TestMethod]
+        public void DeserializeArrayToNonArrayWithPermissiveModeOn()
+        {
+            var stream = serializerWithPermissiveModeOn.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+
+            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
+            Assert.IsNull(deserialized);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void DeserializeArrayToNonArrayWithPermissiveModeOff()
+        {
+            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+
+            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonListSerializerTest.cs
@@ -9,9 +9,6 @@ namespace Amazon.Ion.ObjectMapper.Test
     [TestClass]
     public class IonListSerializerTest
     {
-        IonSerializer serializerWithPermissiveModeOn = new IonSerializer(new IonSerializationOptions { PermissiveMode = true });
-        IonSerializer serializerWithPermissiveModeOff = new IonSerializer(new IonSerializationOptions { PermissiveMode = false });
-
         [TestMethod]
         public void SerializesAndDeserializesLists()
         {
@@ -33,91 +30,66 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DeserializeListToNonListWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
-
-            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
-            Assert.IsNull(deserialized);
+            CheckPermissiveMode(new int[] { 1, 1, 2, 3, 5, 8, 11 }, true, new Teacher(), true);
         }
 
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void DeserializeListToNonListWithPermissiveModeOff()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
-
-            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+            CheckPermissiveMode(new int[] { 1, 1, 2, 3, 5, 8, 11 }, false, new Teacher());
         }
 
         [TestMethod]
         public void DeserializeNonGenericListsToNonListWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
-            Assert.IsNull(deserialized);
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, true, new Teacher(), true);
         }
 
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void DeserializeNonGenericListsToNonListWithPermissiveModeOff()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, false, new Teacher());
         }
 
         [TestMethod]
         public void DeserializeArrayToNonArrayWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
-
-            var deserialized = serializerWithPermissiveModeOn.Deserialize<Teacher>(stream);
-            Assert.IsNull(deserialized);
+            CheckPermissiveMode(new int[] { 1, 1, 2, 3, 5, 8, 11 }, true, new Teacher(), true);
         }
 
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void DeserializeArrayToNonArrayWithPermissiveModeOff()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new int[] { 1, 1, 2, 3, 5, 8, 11 });
-
-            serializerWithPermissiveModeOff.Deserialize<Teacher>(stream);
+            CheckPermissiveMode(new int[] { 1, 1, 2, 3, 5, 8, 11 }, false, new Teacher());
         }
 
         [TestMethod]
         [ExpectedException(typeof(InvalidCastException))]
         public void DeserializeNonGenericListToArrayWithPermissiveModeOff()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            serializerWithPermissiveModeOff.Deserialize<int[]>(stream);
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, false, new int[] { });
         }
 
         [TestMethod]
         public void DeserializeNonGenericListToArrayWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            var deserialized = serializerWithPermissiveModeOn.Deserialize<int[]>(stream);
-            Assert.AreEqual(new int[] { 1, 0, 0 }.ToString(), deserialized.ToString());
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, true, new int[] {1, 0, 0 });
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void DeserializeNonGenericListToGenericListWithPermissiveModeOff()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            serializerWithPermissiveModeOff.Deserialize<List<int>>(stream);
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, false, new List<int> { });
         }
 
         [TestMethod]
         public void DeserializeNonGenericListToGenericListWithPermissiveModeOn()
         {
-            var stream = serializerWithPermissiveModeOff.Serialize(new ArrayList() { 1, "two", 3.14d });
-
-            var deserialized = serializerWithPermissiveModeOn.Deserialize<List<int>>(stream);
-            Assert.AreEqual(new List<int>() { 1, 0, 0 }.ToString(), deserialized.ToString());
+            CheckPermissiveMode(new ArrayList() { 1, "two", 3.14d }, true, new List<int> { 1, 0, 0});
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -486,5 +486,18 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.AreEqual(-TestObjects.honda.Weight, deserialized.Weight);
             Assert.AreEqual(TestObjects.honda.Engine.ManufactureDate.AddDays(1), deserialized.Engine.ManufactureDate);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void DeserializeObjectWithMismatchTypePropertyAndPermissiveModeOff()
+        {
+            CheckPermissiveMode(TestObjects.JohnGreenwood, false, new StudentWithIntFirstName(0, "Greenwood", "Physics"));
+        }
+
+        [TestMethod]
+        public void DeserializeObjectWithMismatchTypePropertyAndPermissiveModeOn()
+        {
+            CheckPermissiveMode(TestObjects.JohnGreenwood, true, new StudentWithIntFirstName(0, "Greenwood", "Physics"));
+        }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
@@ -32,6 +32,26 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void DeserializePrimitivesToWrongTypeWithPermissiveModeOn()
+        {
+            CheckPermissiveMode((object)null, true, new Teacher(), true);
+            CheckPermissiveMode(false, true, new Teacher(), true);
+            CheckPermissiveMode(true, true, new Teacher(), true);
+            CheckPermissiveMode(2010, true, new Teacher(), true);
+            CheckPermissiveMode(20102011L, true, new Teacher(), true);
+            CheckPermissiveMode(3.14159f, true, new Teacher(), true);
+            CheckPermissiveMode(6.02214076e23d, true, new Teacher(), true);
+            CheckPermissiveMode(567.9876543m, true, new Teacher(), true);
+            CheckPermissiveMode(BigDecimal.Parse("2.71828"), true, new Teacher(), true);
+            CheckPermissiveMode(DateTime.Parse("2009-10-10T13:15:21Z"), true, new Teacher(), true);
+            CheckPermissiveMode("Civic", true, new Teacher(), true);
+            CheckPermissiveMode(new SymbolToken("my symbol", SymbolToken.UnknownSid), true, new Teacher(), true);
+            CheckPermissiveMode(Encoding.UTF8.GetBytes("This is an Ion blob"), true, new Teacher(), true);
+            CheckPermissiveMode(MakeIonClob("This is an Ion clob"), true, new Teacher(), true);
+            CheckPermissiveMode(Guid.NewGuid(), true, new Teacher(), true);
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesLists()
         {
             Check(new int[] { 1, 1, 2, 3, 5, 8, 11 });

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -369,6 +369,32 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
+    public class StudentWithIntFirstName
+    {
+        public int FirstName { get; init; }
+        public string LastName { get; init; }
+        public string Major { get; }
+
+        public StudentWithIntFirstName()
+        {
+            this.FirstName = default;
+            this.LastName = default;
+            this.Major = default;
+        }
+
+        public StudentWithIntFirstName(int firstName, string lastName, string major)
+        {
+            this.FirstName = firstName;
+            this.LastName = lastName;
+            this.Major = major;
+        }
+
+        public override string ToString()
+        {
+            return $"<Student>{{ FirstName: {FirstName}, LastName: {LastName}, Major: {Major} }}";
+        }
+    }
+
     public class Country
     {
         public string Name { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -70,6 +70,25 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.AreEqual(item.ToString(), Serde(ionSerializer, item).ToString());
         }
 
+        public static void CheckPermissiveMode<T>(object item, bool permissiveMode, T expectedType, bool expectedNull = false)
+        {
+            var stream = new IonSerializer().Serialize(item);
+
+            var serializer = new IonSerializer(new IonSerializationOptions { PermissiveMode = permissiveMode });
+
+            var deserialized =  serializer.Deserialize<T>(stream);
+
+            if (expectedNull)
+            {
+                Assert.IsNull(deserialized);
+            }
+            else
+            {
+                Assert.AreEqual(deserialized.GetType(), expectedType.GetType());
+                Assert.AreEqual(expectedType.ToString(), deserialized.ToString());
+            }
+        }
+
         public static void AssertHasAnnotation(string annotation, Stream stream)
         {
             AssertHasAnnotation(annotation, StreamToIonValue(Copy(stream)));

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -70,13 +70,18 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.AreEqual(item.ToString(), Serde(ionSerializer, item).ToString());
         }
 
-        public static void CheckPermissiveMode<T>(object item, bool permissiveMode, T expectedType, bool expectedNull = false)
+        public static void CheckPermissiveMode<T>(object item, bool isPermissiveMode, T expectedType, bool expectedNull = false)
         {
             var stream = new IonSerializer().Serialize(item);
 
-            var serializer = new IonSerializer(new IonSerializationOptions { PermissiveMode = permissiveMode });
+            CheckPermissiveMode(stream, isPermissiveMode, expectedType, expectedNull);
+        }
 
-            var deserialized =  serializer.Deserialize<T>(stream);
+        public static void CheckPermissiveMode<T>(Stream stream, bool isPermissiveMode, T expectedType, bool expectedNull = false)
+        {
+            var serializer = new IonSerializer(new IonSerializationOptions { PermissiveMode = isPermissiveMode });
+
+            var deserialized = serializer.Deserialize<T>(stream);
 
             if (expectedNull)
             {

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -10,23 +10,23 @@ namespace Amazon.Ion.ObjectMapper
         private readonly Type listType;
         private readonly Type elementType;
         private readonly bool isGenericList;
-        private readonly bool permissiveMode;
+        private readonly bool isPermissiveMode;
 
-        public IonListSerializer(IonSerializer serializer, Type listType, Type elementType, bool permissiveMode)
+        public IonListSerializer(IonSerializer serializer, Type listType, Type elementType, bool isPermissiveMode)
         {
             this.serializer = serializer;
             this.listType = listType;
             this.elementType = elementType;
             this.isGenericList = true;
-            this.permissiveMode = permissiveMode;
+            this.isPermissiveMode = isPermissiveMode;
         }
 
-        public IonListSerializer(IonSerializer serializer, Type listType, bool permissiveMode)
+        public IonListSerializer(IonSerializer serializer, Type listType, bool isPermissiveMode)
         {
             this.serializer = serializer;
             this.listType = listType;
             this.isGenericList = false;
-            this.permissiveMode = permissiveMode;
+            this.isPermissiveMode = isPermissiveMode;
         }
 
         public override System.Collections.IList Deserialize(IIonReader reader)
@@ -51,7 +51,7 @@ namespace Amazon.Ion.ObjectMapper
                     }
                     catch (Exception)
                     {
-                        if (permissiveMode)
+                        if (isPermissiveMode)
                         {
                             typedArray.SetValue(Activator.CreateInstance(elementType), i);
                         }
@@ -83,7 +83,7 @@ namespace Amazon.Ion.ObjectMapper
                     }
                     catch (Exception)
                     {
-                        if (permissiveMode)
+                        if (isPermissiveMode)
                         {
                             typedList.Add(Activator.CreateInstance(elementType));
                         }

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -49,9 +49,9 @@ namespace Amazon.Ion.ObjectMapper
                     {
                         typedArray.SetValue(list[i], i);
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        if (isPermissiveMode)
+                        if (isPermissiveMode && (e is ArgumentException || e is InvalidCastException))
                         {
                             typedArray.SetValue(Activator.CreateInstance(elementType), i);
                         }
@@ -81,9 +81,9 @@ namespace Amazon.Ion.ObjectMapper
                     {
                         typedList.Add(element);
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        if (isPermissiveMode)
+                        if (isPermissiveMode && e is ArgumentException)
                         {
                             typedList.Add(Activator.CreateInstance(elementType));
                         }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -48,8 +48,21 @@ namespace Amazon.Ion.ObjectMapper
                     {
                         continue;
                     }
-
-                    property.SetValue(targetObject, deserialized);
+                    try
+                    {
+                        property.SetValue(targetObject, deserialized);
+                    }
+                    catch (ArgumentException)
+                    {
+                        if (options.PermissiveMode)
+                        {
+                            property.SetValue(targetObject, Activator.CreateInstance(property.PropertyType));
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
                 }
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -305,14 +305,15 @@ namespace Amazon.Ion.ObjectMapper
                 return new IonListSerializer(this, listType, permissiveMode);
             }
 
-            if (permissiveMode)
-            {
-                return new IonListSerializer(this, listType, true);
-            }
-            else
-            {
-                throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
-            }
+            throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
+            //if (permissiveMode)
+            //{
+            //    return new IonListSerializer(this, listType, true);
+            //}
+            //else
+            //{
+            //    throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
+            //}
         }
 
 
@@ -443,7 +444,7 @@ namespace Amazon.Ion.ObjectMapper
             {
                 return (T)Deserialize(reader, typeof(T));
             }
-            catch (InvalidCastException)
+            catch (NotSupportedException)
             {
                 if (options.PermissiveMode)
                 {

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -289,20 +289,20 @@ namespace Amazon.Ion.ObjectMapper
             throw new NotSupportedException($"Do not know how to serialize type {typeof(T)}");
         }
 
-        private IonListSerializer NewIonListSerializer(Type listType, bool permissiveMode) 
+        private IonListSerializer NewIonListSerializer(Type listType, bool isPermissiveMode) 
         {
             if (listType.IsArray)
             {
-                return new IonListSerializer(this, listType, listType.GetElementType(), permissiveMode);
+                return new IonListSerializer(this, listType, listType.GetElementType(), isPermissiveMode);
             }
             
             if (listType.IsAssignableTo(typeof(System.Collections.IList)))
             {
                 if (listType.IsGenericType)
                 {
-                    return new IonListSerializer(this, listType, listType.GetGenericArguments()[0], permissiveMode);
+                    return new IonListSerializer(this, listType, listType.GetGenericArguments()[0], isPermissiveMode);
                 }
-                return new IonListSerializer(this, listType, permissiveMode);
+                return new IonListSerializer(this, listType, isPermissiveMode);
             }
 
             throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -293,21 +293,21 @@ namespace Amazon.Ion.ObjectMapper
         {
             if (listType.IsArray)
             {
-                return new IonListSerializer(this, listType, listType.GetElementType());
+                return new IonListSerializer(this, listType, listType.GetElementType(), permissiveMode);
             }
             
             if (listType.IsAssignableTo(typeof(System.Collections.IList)))
             {
                 if (listType.IsGenericType)
                 {
-                    return new IonListSerializer(this, listType, listType.GetGenericArguments()[0]);
+                    return new IonListSerializer(this, listType, listType.GetGenericArguments()[0], permissiveMode);
                 }
-                return new IonListSerializer(this, listType);
+                return new IonListSerializer(this, listType, permissiveMode);
             }
 
             if (permissiveMode)
             {
-                return new IonListSerializer(this, listType);
+                return new IonListSerializer(this, listType, true);
             }
             else
             {

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -436,12 +436,13 @@ namespace Amazon.Ion.ObjectMapper
             {
                 return (T)Deserialize(reader, typeof(T));
             }
-            catch (NotSupportedException)
+            catch (Exception e)
             {
-                if (options.PermissiveMode)
+                if (options.PermissiveMode && (e is NotSupportedException || e is InvalidCastException))
                 {
                     return default(T);
-                } else
+                }
+                else
                 {
                     throw;
                 }

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -306,14 +306,6 @@ namespace Amazon.Ion.ObjectMapper
             }
 
             throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
-            //if (permissiveMode)
-            //{
-            //    return new IonListSerializer(this, listType, true);
-            //}
-            //else
-            //{
-            //    throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
-            //}
         }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Permissive mode is an option that the user can specify and will deserialize Ion data to incorrect types successfully by returning the default value of the type. The default option is false. 

This feature is important for users with large amount of legacy data that may have some parts that are incorrect but want to be deserialized successfully. 

* List type deserialization
  *  Ion list deserialized to non-list type will return default value of the non-list type.
     * e.g. Ion list : `1, "two", 3.14d` converted to `Teacher `object will return default value of `Teacher` object.
  *  Ion list containing values of different types deserialized to a generic list will return the generic list containing the values of the correct type. If there is a type mismatch, it will set to the default value of the expected type.
     * e.g. Ion list : `1, "two", 3.14d` converted to `List<int>` will return `new List<int>() {1, 0, 0}`.

* Primitive type deserialization
  * Primitive type deserialized to another type will return default value of the other type.
    * e.g. int converted to `Teacher` object will return default value of `Teacher` object.

* Object type deserialization
  * Object with property deserialized to another Object with same property name but different type will return default value of the different type.
    *  e.g. Person object with string first name deserialized to Person object with int first name will return `Person {firstName: 0}`
  * WIP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
