### PR TITLE
Implement IgnoreReadOnlyProperties option

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -59,6 +59,30 @@ namespace Amazon.Ion.ObjectMapper.Test
             Assert.IsNotNull(deserialized.department);
             Assert.IsNull(deserialized.birthDate);
         }
+        
+        [TestMethod]
+        public void SerializesObjectsWithIgnoreReadOnlyProperties()
+        {
+            var serializer = new IonSerializer(new IonSerializationOptions {IgnoreReadOnlyProperties = true});
+            IIonStruct serialized = StreamToIonValue(serializer.Serialize(TestObjects.JohnGreenwood));
+            
+            Assert.IsTrue(serialized.ContainsField("firstName"));
+            Assert.IsTrue(serialized.ContainsField("lastName"));
+            Assert.IsFalse(serialized.ContainsField("<Major>k__BackingField"));
+        }
+        
+        [TestMethod]
+        public void DeserializesObjectsWithIgnoreReadOnlyProperties()
+        {
+            var stream = new IonSerializer().Serialize(TestObjects.JohnGreenwood);
+
+            var serializer = new IonSerializer(new IonSerializationOptions {IgnoreReadOnlyProperties = true});
+            var deserialized = serializer.Deserialize<Student>(stream);
+            
+            Assert.AreEqual(TestObjects.JohnGreenwood.FirstName, deserialized.FirstName);
+            Assert.AreEqual(TestObjects.JohnGreenwood.LastName, deserialized.LastName);
+            Assert.AreNotEqual(TestObjects.JohnGreenwood.Major, deserialized.Major);
+        }
 
         [TestMethod]
         public void SerializesObjectsWithIgnoreDefaults()

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -150,6 +150,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         public static Teacher drFord = new Teacher("Rachel", "Ford", "Chemistry", DateTime.ParseExact("29/04/1985", "dd/MM/yyyy", CultureInfo.InvariantCulture));
         private static Teacher[] faculty = { drKyler, drFord };
         public static School fieldAcademy = new School("1234 Fictional Ave", 150, new List<Teacher>(faculty));
+        
+        public static Student JohnGreenwood = new Student("John", "Greenwood", "Physics");
 
         private static Politician GeorgeAdams = new Politician {FirstName = "George", LastName = "Adams" };
         private static Politician SuzanneBenson = new Politician {FirstName = "Suzanne", LastName = "Benson" };
@@ -338,6 +340,32 @@ namespace Amazon.Ion.ObjectMapper.Test
         public override string ToString()
         {
             return "<Teacher>{ firstName: " + firstName + ", lastName: " + lastName + ", department: " + department + ", birthDate: " + birthDate + " }";
+        }
+    }
+
+    public class Student
+    {
+        public string FirstName { get; init; }
+        public string LastName { get; init; }
+        public string Major { get; }
+
+        public Student()
+        {
+            this.FirstName = default;
+            this.LastName = default;
+            this.Major = default;
+        }
+        
+        public Student(string firstName, string lastName, string major)
+        {
+            this.FirstName = firstName;
+            this.LastName = lastName;
+            this.Major = major;
+        }
+        
+        public override string ToString()
+        {
+            return $"<Student>{{ FirstName: {FirstName}, LastName: {LastName}, Major: {Major} }}";
         }
     }
 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -157,7 +157,9 @@ namespace Amazon.Ion.ObjectMapper
             }
 
             var name = options.NamingConvention.ToProperty(readName);
-            return targetType.GetProperty(name);
+            var property = targetType.GetProperty(name, BINDINGS);
+
+            return property;
         }
 
         private bool IsReadOnlyProperty(PropertyInfo property)

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -8,7 +8,7 @@ namespace Amazon.Ion.ObjectMapper
 {
     public class IonObjectSerializer : IonSerializer<object>
     {
-        private const BindingFlags fieldBindings = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
+        private const BindingFlags BINDINGS = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
         private readonly IonSerializer ionSerializer;
         private readonly IonSerializationOptions options;
         private readonly Type targetType;
@@ -81,7 +81,6 @@ namespace Amazon.Ion.ObjectMapper
                 {
                     continue;
                 }
-                
 
                 if (this.options.IgnoreReadOnlyProperties && IsReadOnlyProperty(property))
                 {
@@ -168,7 +167,7 @@ namespace Amazon.Ion.ObjectMapper
         
         private FieldInfo FindField(string name)
         {
-            var exact = targetType.GetField(name, fieldBindings);
+            var exact = targetType.GetField(name, BINDINGS);
             if (exact != null && IsField(exact))
             {
                 return exact;
@@ -213,7 +212,7 @@ namespace Amazon.Ion.ObjectMapper
 
         private IEnumerable<FieldInfo> Fields()
         {
-            return targetType.GetFields(fieldBindings).Where(IsField);
+            return targetType.GetFields(BINDINGS).Where(IsField);
         }
 
         private IEnumerable<PropertyInfo> IonNamedProperties()

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -108,7 +108,7 @@ namespace Amazon.Ion.ObjectMapper
         public bool IncludeFields { get; init; } = false;
         public bool IgnoreNulls { get; init; } = false;
         public bool IgnoreReadOnlyFields { get; init; } = false;
-        public readonly bool IgnoreReadOnlyProperties;
+        public bool IgnoreReadOnlyProperties { get; init; } = false;
         public bool PropertyNameCaseInsensitive { get; init; } = false;
         public bool IgnoreDefaults { get; init; } = false;
         public bool IncludeTypeInformation { get; init; } = false;


### PR DESCRIPTION
Resolves #7.

Option to determine whether or not to ignore read only properties during serialization/deserialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.