### PR TITLE
Introduce a super-interface of IonSerializer

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Amazon.IonDotnet;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -34,6 +35,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void SerializesAndDeserializesLists()
         {
             Check(new int[] { 1, 1, 2, 3, 5, 8, 11 });
+
+            var d = new Dictionary<Type, IonSerializer<dynamic>>();
         }
     }
 }

--- a/Amazon.Ion.ObjectMapper/IonListSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonListSerializer.cs
@@ -26,7 +26,7 @@ namespace Amazon.Ion.ObjectMapper
             this.isGenericList = false;
         }
 
-        public System.Collections.IList Deserialize(IIonReader reader)
+        public override System.Collections.IList Deserialize(IIonReader reader)
         {
             reader.StepIn();
             var list = new System.Collections.ArrayList();
@@ -68,7 +68,7 @@ namespace Amazon.Ion.ObjectMapper
             throw new NotSupportedException("Don't know how to make a list of type " + listType + " with element type " + elementType);
         }
 
-        public void Serialize(IIonWriter writer, System.Collections.IList item)
+        public override void Serialize(IIonWriter writer, System.Collections.IList item)
         {
             writer.StepIn(IonType.List);
             foreach (var i in item)

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -23,7 +23,7 @@ namespace Amazon.Ion.ObjectMapper
                 () => this.targetType.GetProperties().Where(IsReadOnlyProperty));
         }
 
-        public object Deserialize(IIonReader reader)
+        public override object Deserialize(IIonReader reader)
         {
             var targetObject = options.ObjectFactory.Create(options, reader, targetType);
             reader.StepIn();
@@ -71,7 +71,7 @@ namespace Amazon.Ion.ObjectMapper
             return targetObject;
         }
 
-        public void Serialize(IIonWriter writer, object item)
+        public override void Serialize(IIonWriter writer, object item)
         {
             options.TypeAnnotator.Apply(options, writer, targetType);
             writer.StepIn(IonType.Struct);

--- a/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
+++ b/Amazon.Ion.ObjectMapper/IonPrimitiveSerializers.cs
@@ -8,12 +8,12 @@ namespace Amazon.Ion.ObjectMapper
 {
     public class IonNullSerializer : IonSerializer<object>
     {
-        public object Deserialize(IIonReader reader)
+        public override object Deserialize(IIonReader reader)
         {
             return null;
         }
 
-        public void Serialize(IIonWriter writer, object item)
+        public override void Serialize(IIonWriter writer, object item)
         {
             writer.WriteNull();
         }
@@ -21,26 +21,26 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonByteArraySerializer : IonSerializer<byte[]>
     {
-        public byte[] Deserialize(IIonReader reader)
+        public override byte[] Deserialize(IIonReader reader)
         {
             byte[] blob = new byte[reader.GetLobByteSize()];
             reader.GetBytes(blob);
             return blob;
         }
 
-        public void Serialize(IIonWriter writer, byte[] item)
+        public override void Serialize(IIonWriter writer, byte[] item)
         {
             writer.WriteBlob(item);
         }
     }
     public class IonStringSerializer : IonSerializer<string>
     {
-        public string Deserialize(IIonReader reader)
+        public override string Deserialize(IIonReader reader)
         {
             return reader.StringValue();
         }
 
-        public void Serialize(IIonWriter writer, string item)
+        public override void Serialize(IIonWriter writer, string item)
         {
             writer.WriteString(item);
         }
@@ -48,12 +48,12 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonIntSerializer : IonSerializer<int>
     {
-        public int Deserialize(IIonReader reader)
+        public override int Deserialize(IIonReader reader)
         {
             return reader.IntValue();
         }
 
-        public void Serialize(IIonWriter writer, int item)
+        public override void Serialize(IIonWriter writer, int item)
         {
             writer.WriteInt(item);
         }
@@ -63,12 +63,12 @@ namespace Amazon.Ion.ObjectMapper
     {
         internal static readonly string ANNOTATION = "numeric.int32";
 
-        public long Deserialize(IIonReader reader)
+        public override long Deserialize(IIonReader reader)
         {
             return reader.IntValue();
         }
 
-        public void Serialize(IIonWriter writer, long item)
+        public override void Serialize(IIonWriter writer, long item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteInt(item);
@@ -76,12 +76,12 @@ namespace Amazon.Ion.ObjectMapper
     }
     public class IonBooleanSerializer : IonSerializer<bool>
     {
-        public bool Deserialize(IIonReader reader)
+        public override bool Deserialize(IIonReader reader)
         {
             return reader.BoolValue();
         }
 
-        public void Serialize(IIonWriter writer, bool item)
+        public override void Serialize(IIonWriter writer, bool item)
         {
             writer.WriteBool(item);
         }
@@ -89,12 +89,12 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonDoubleSerializer : IonSerializer<double>
     {
-        public double Deserialize(IIonReader reader)
+        public override double Deserialize(IIonReader reader)
         {
             return reader.DoubleValue();
         }
 
-        public void Serialize(IIonWriter writer, double item)
+        public override void Serialize(IIonWriter writer, double item)
         {
             writer.WriteFloat(item);
         }
@@ -104,12 +104,12 @@ namespace Amazon.Ion.ObjectMapper
     {
         internal static readonly string ANNOTATION = "numeric.decimal128";
 
-        public decimal Deserialize(IIonReader reader)
+        public override decimal Deserialize(IIonReader reader)
         {
             return reader.DecimalValue().ToDecimal();
         }
 
-        public void Serialize(IIonWriter writer, decimal item)
+        public override void Serialize(IIonWriter writer, decimal item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteDecimal(item);
@@ -118,12 +118,12 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonBigDecimalSerializer : IonSerializer<BigDecimal>
     {
-        public BigDecimal Deserialize(IIonReader reader)
+        public override BigDecimal Deserialize(IIonReader reader)
         {
             return reader.DecimalValue();
         }
 
-        public void Serialize(IIonWriter writer, BigDecimal item)
+        public override void Serialize(IIonWriter writer, BigDecimal item)
         {
             writer.WriteDecimal(item);
         }
@@ -133,13 +133,13 @@ namespace Amazon.Ion.ObjectMapper
     {
         internal static readonly string ANNOTATION = "numeric.float32";
 
-        public float Deserialize(IIonReader reader)
+        public override float Deserialize(IIonReader reader)
         {
             
             return Convert.ToSingle(reader.DoubleValue());
         }
 
-        public void Serialize(IIonWriter writer, float item)
+        public override void Serialize(IIonWriter writer, float item)
         {
             writer.SetTypeAnnotations(new List<string>() { ANNOTATION });
             writer.WriteFloat(item);
@@ -148,12 +148,12 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonDateTimeSerializer : IonSerializer<DateTime>
     {
-        public DateTime Deserialize(IIonReader reader)
+        public override DateTime Deserialize(IIonReader reader)
         {
             return reader.TimestampValue().DateTimeValue;
         }
 
-        public void Serialize(IIonWriter writer, DateTime item)
+        public override void Serialize(IIonWriter writer, DateTime item)
         {
             writer.WriteTimestamp(new Timestamp(item));
         }
@@ -161,12 +161,12 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonSymbolSerializer : IonSerializer<SymbolToken>
     {
-        public SymbolToken Deserialize(IIonReader reader)
+        public override SymbolToken Deserialize(IIonReader reader)
         {
             return reader.SymbolValue();
         }
 
-        public void Serialize(IIonWriter writer, SymbolToken item)
+        public override void Serialize(IIonWriter writer, SymbolToken item)
         {
             writer.WriteSymbolToken(item);
         }
@@ -174,14 +174,14 @@ namespace Amazon.Ion.ObjectMapper
 
     public class IonClobSerializer : IonSerializer<string>
     {
-        public string Deserialize(IIonReader reader)
+        public override string Deserialize(IIonReader reader)
         {
             byte[] clob = new byte[reader.GetLobByteSize()];
             reader.GetBytes(clob);
             return Encoding.UTF8.GetString(clob);
         }
 
-        public void Serialize(IIonWriter writer, string item)
+        public override void Serialize(IIonWriter writer, string item)
         {
             writer.WriteClob(Encoding.UTF8.GetBytes(item));
         }
@@ -197,14 +197,14 @@ namespace Amazon.Ion.ObjectMapper
             this.options = options;
         }
 
-        public Guid Deserialize(IIonReader reader)
+        public override Guid Deserialize(IIonReader reader)
         {
             byte[] blob = new byte[reader.GetLobByteSize()];
             reader.GetBytes(blob);
             return new Guid(blob);
         }
 
-        public void Serialize(IIonWriter writer, Guid item)
+        public override void Serialize(IIonWriter writer, Guid item)
         {
             if (options.AnnotateGuids) {
                 writer.SetTypeAnnotations(new List<string>() { ANNOTATION });

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -7,10 +7,26 @@ using static Amazon.Ion.ObjectMapper.IonSerializationFormat;
 
 namespace Amazon.Ion.ObjectMapper
 {
-    public interface IonSerializer<T>
+    public interface IIonSerializer
     {
-        void Serialize(IIonWriter writer, T item);
-        T Deserialize(IIonReader reader);
+        void Serialize(IIonWriter writer, object item);
+        object Deserialize(IIonReader reader);
+    }
+
+    public abstract class IonSerializer<T> : IIonSerializer
+    {
+        public abstract void Serialize(IIonWriter writer, T item);
+        public abstract T Deserialize(IIonReader reader);
+
+        void IIonSerializer.Serialize(IIonWriter writer, object item)
+        {
+            Serialize(writer, (T)item);
+        }
+
+        object IIonSerializer.Deserialize(IIonReader reader)
+        {
+            return Deserialize(reader);
+        }
     }
 
     public interface IonSerializationContext


### PR DESCRIPTION
This is so that later non-generic serializers can be added for converting between object and Ion and vice versa

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
