### PR TITLE
Implement AnnotatedIonSerializers

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
@@ -36,5 +36,27 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             Check(new int[] { 1, 1, 2, 3, 5, 8, 11 });
         }
+
+        // This currently fails due to default annotation behavior. Passes when PR #17 is merged
+        // [TestMethod]
+        public void AnnotatedIonSerializer()
+        {
+            var annotatedIonSerializer = new Dictionary<string, IIonSerializer>();
+            var annotatedIonDeserializer = new Dictionary<string, IIonSerializer>();
+            annotatedIonSerializer.Add("OEM.Manufacturer", new SupraManufacturerSerializer());
+            annotatedIonDeserializer.Add("OEM.Manufacturer", new SupraManufacturerDeserializer());
+
+            var customizedSerializer = new IonSerializer(new IonSerializationOptions { AnnotatedIonSerializers = annotatedIonSerializer });
+            var customizedDeserializer = new IonSerializer(new IonSerializationOptions { AnnotatedIonSerializers = annotatedIonDeserializer });
+
+            var stream = customizedSerializer.Serialize(TestObjects.a90);
+            var defaultStream = customizedDeserializer.Serialize(TestObjects.a90);
+
+            var outputCustomSerialize = customizedSerializer.Deserialize<Supra>(stream);
+            var outputCustomDeserialize = customizedDeserializer.Deserialize<Supra>(defaultStream);
+
+            Assert.AreEqual("BMW", outputCustomSerialize.Brand);
+            Assert.AreEqual("BMW", outputCustomDeserialize.Brand);
+        }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -63,7 +63,13 @@ namespace Amazon.Ion.ObjectMapper.Test
             return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";
         }
     }
-    
+
+    public class Supra : Vehicle
+    {
+        [IonAnnotateType(Name = "Manufacturer", Prefix = "OEM")]
+        public string Brand { get; set; } = "Toyota";
+    }
+
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Yacht : Boat
     {
@@ -141,6 +147,8 @@ namespace Amazon.Ion.ObjectMapper.Test
             Weight = new Random().NextDouble(),
             Engine = new Engine { Cylinders = 4, ManufactureDate = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
+
+        public static Supra a90 = new Supra();
 
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 

--- a/Amazon.Ion.ObjectMapper.Test/TestSerializers.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestSerializers.cs
@@ -161,4 +161,30 @@ namespace Amazon.Ion.ObjectMapper.Test
             writer.WriteBlob(new byte[item.ToByteArray().Length]);
         }
     }
+
+    public class SupraManufacturerDeserializer : IonSerializer<string>
+    {
+        public override string Deserialize(IIonReader reader)
+        {
+            return "BMW";
+        }
+
+        public override void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString(item);
+        }
+    }
+
+    public class SupraManufacturerSerializer : IonSerializer<string>
+    {
+        public override string Deserialize(IIonReader reader)
+        {
+            return reader.StringValue();
+        }
+
+        public override void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString("BMW");
+        }
+    }
 }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -98,6 +98,13 @@ namespace Amazon.Ion.ObjectMapper
                 }
 
                 writer.SetFieldName(IonFieldNameFromProperty(property));
+
+                var ionAnnotateTypes = (IEnumerable<IonAnnotateType>)property.GetCustomAttributes(typeof(IonAnnotateType));
+                if (ionSerializer.TryAnnotatedIonSerializer(writer, propertyValue, ionAnnotateTypes))
+                {
+                    continue;
+                }
+
                 ionSerializer.Serialize(writer, propertyValue);
             }
 
@@ -119,6 +126,13 @@ namespace Amazon.Ion.ObjectMapper
                 }
 
                 writer.SetFieldName(GetFieldName(field));
+
+                var ionAnnotateTypes = (IEnumerable<IonAnnotateType>)field.GetCustomAttributes(typeof(IonAnnotateType));
+                if (ionSerializer.TryAnnotatedIonSerializer(writer, fieldValue, ionAnnotateTypes))
+                {
+                    continue;
+                }
+
                 ionSerializer.Serialize(writer, fieldValue);
             }
             writer.StepOut();

--- a/Amazon.Ion.ObjectMapper/IonSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonSerializer.cs
@@ -146,6 +146,8 @@ namespace Amazon.Ion.ObjectMapper
         public readonly bool PermissiveMode;
         
         public Dictionary<Type, IIonSerializer> IonSerializers { get; init; }
+
+        public Dictionary<string, IIonSerializer> AnnotatedIonSerializers { get; init; }
     }
 
     public interface IonSerializerFactory<T, TContext> where TContext : IonSerializationContext
@@ -188,6 +190,13 @@ namespace Amazon.Ion.ObjectMapper
             if (item == null)
             {
                 new IonNullSerializer().Serialize(writer, null);
+                return;
+            }
+
+            Type type = item.GetType();
+            var ionAnnotateTypes = (IEnumerable<IonAnnotateType>)type.GetCustomAttributes(typeof(IonAnnotateType), false);
+            if (TryAnnotatedIonSerializer(writer, item, ionAnnotateTypes))
+            {
                 return;
             }
 
@@ -287,7 +296,7 @@ namespace Amazon.Ion.ObjectMapper
                 return;
             }
 
-            throw new NotSupportedException($"Do not know how to serialize type {typeof(T)}");
+            throw new NotSupportedException($"Do not know how to serialize type {type}");
         }
 
         private IonListSerializer NewIonListSerializer(Type listType) 
@@ -309,6 +318,31 @@ namespace Amazon.Ion.ObjectMapper
             throw new NotSupportedException("Encountered an Ion list but the desired deserialized type was not an IList, it was: " + listType);
         }
 
+        internal bool TryAnnotatedIonSerializer<T>(IIonWriter writer, T item, IEnumerable<IonAnnotateType> annotationAttributes)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            Type itemType = item.GetType();
+
+            if (options.AnnotatedIonSerializers != null)
+            {
+                foreach (IonAnnotateType annotationAttribute in annotationAttributes)
+                {
+                    string standardizedAnnotation = options.AnnotationConvention.Apply(annotationAttribute, itemType);
+                    if (options.AnnotatedIonSerializers.ContainsKey(standardizedAnnotation))
+                    {
+                        var serializer = options.AnnotatedIonSerializers[standardizedAnnotation];
+                        writer.AddTypeAnnotation(standardizedAnnotation);
+                        serializer.Serialize(writer, item);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
 
         public T Deserialize<T>(Stream stream)
         {
@@ -325,6 +359,17 @@ namespace Amazon.Ion.ObjectMapper
             if (reader.CurrentDepth > this.options.MaxDepth)
             {
                 return null;
+            }
+
+            if (options.AnnotatedIonSerializers != null)
+            {
+                foreach (var valuePair in options.AnnotatedIonSerializers)
+                {
+                    if (reader.HasAnnotation(valuePair.Key))
+                    {
+                        return valuePair.Value.Deserialize(reader);
+                    }
+                }
             }
 
             if (ionType == IonType.None || ionType == IonType.Null)


### PR DESCRIPTION
Implement AnnotatedIonSerializers

This PR replaces #18 

This change allows the user to configure a `IDictionary<string, IIonSerializer>` where the string is an Ion Type annotation.

On Serialization, if the type of c# object being serialized has an `IonAnnotateType` attribute, it will apply the current `AnnotationConvention` rule to it, which gives a string. If this string matches the key in the dictionary, it will use the mapped `IIonSerializer` value to serialize the object.

On Deserialization, it will get the current `TypeAnnotations` from the Ion object as a string, and similarly use it to find the serializer to use for deserialization in the library.