### PR TITLE
Implement method serialization/deserialization

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -139,31 +139,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void SerializesAndDeserializesGetterAndSetterMethods()
         {
-            var serializer = new IonSerializer();
-            var ruler = new Ruler {length = 30, unit = "cm"};
-
-            var stream = serializer.Serialize(ruler);
-            IIonStruct serialized = StreamToIonValue(stream);
-
-            // We should have exactly two fields. ie. we did not double serialize length or unit.
-            Assert.AreEqual(2, serialized.Count);
-            
-            Assert.IsTrue(serialized.ContainsField("length"));
-            Assert.IsTrue(serialized.ContainsField("unit"));
-
-            // The ruler's length getter returns 10 more than the actual size.
-            Assert.AreEqual(ruler.length + 10, serialized.GetField("length").IntValue);
-            
-            // The ruler's unit getter returns "centimeter" when the internal unit is "cm".
-            Assert.AreEqual("centimeter", serialized.GetField("unit").StringValue);
-
-            var deserialized = serializer.Deserialize<Ruler>(stream);
-
-            // The ruler's length setter subtracts 10 when setting the size which cancels out the 10 added by the getter.
-            Assert.AreEqual(ruler.length, deserialized.length);
-            
-            // The ruler's unit setter converts "centimeter" back to "cm".
-            Assert.AreEqual(ruler.unit, deserialized.unit);
+            Check(TestObjects.SchoolDesk);
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -137,6 +137,32 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void SerializesAndDeserializesGetterAndSetterMethods()
+        {
+            var serializer = new IonSerializer();
+            var ruler = new Ruler {length = 30, unit = "cm"};
+
+            var stream = serializer.Serialize(ruler);
+            IIonStruct serialized = StreamToIonValue(stream);
+            Assert.IsTrue(serialized.ContainsField("length"));
+            Assert.IsTrue(serialized.ContainsField("unit"));
+
+            // The ruler's length getter returns 10 more than the actual size.
+            Assert.AreEqual(ruler.length + 10, serialized.GetField("length").IntValue);
+            
+            // The ruler's unit getter returns "centimeter" when the internal unit is "cm".
+            Assert.AreEqual("centimeter", serialized.GetField("unit").StringValue);
+
+            var deserialized = serializer.Deserialize<Ruler>(stream);
+
+            // The ruler's length setter subtracts 10 when setting the size which cancels out the 10 added by the getter.
+            Assert.AreEqual(ruler.length, deserialized.length);
+            
+            // The ruler's unit setter converts "centimeter" back to "cm".
+            Assert.AreEqual(ruler.unit, deserialized.unit);
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()
         {
             Check(

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -147,6 +147,9 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             IIonStruct serialized = SerializeToIonValue(TestObjects.Ruler);
 
+            Assert.IsTrue(serialized.ContainsField("length"));
+            Assert.IsTrue(serialized.ContainsField("unit"));
+
             // We should have exactly two fields. ie. we did not double serialize the Ruler's length or unit members.
             Assert.AreEqual(2, serialized.Count);
         }

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -145,7 +145,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         [TestMethod]
         public void DoesNotDoubleSerializeIonFieldsAlreadySerializedByMethods()
         {
-            IIonStruct serialized = SerializeToIonValue(TestObjects.Ruler);
+            IIonStruct serialized = ToIonValue(new IonSerializer(), TestObjects.Ruler);
 
             Assert.IsTrue(serialized.ContainsField("length"));
             Assert.IsTrue(serialized.ContainsField("unit"));

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -144,6 +144,10 @@ namespace Amazon.Ion.ObjectMapper.Test
 
             var stream = serializer.Serialize(ruler);
             IIonStruct serialized = StreamToIonValue(stream);
+
+            // We should have exactly two fields. ie. we did not double serialize length or unit.
+            Assert.AreEqual(2, serialized.Count);
+            
             Assert.IsTrue(serialized.ContainsField("length"));
             Assert.IsTrue(serialized.ContainsField("unit"));
 

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -155,9 +155,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         public void ExceptionOnMultiParameterIonPropertySetterMethods()
         {
             var serializer = new IonSerializer();
-            var chalkboard = new Chalkboard {width = 48, height = 36};
 
-            var stream = serializer.Serialize(chalkboard);
+            var stream = serializer.Serialize(TestObjects.Chalkboard);
             Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Chalkboard>(stream));
         }
 

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -160,7 +160,7 @@ namespace Amazon.Ion.ObjectMapper.Test
             var serializer = new IonSerializer();
 
             var stream = serializer.Serialize(TestObjects.Chalkboard);
-            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Chalkboard>(stream));
+            Assert.ThrowsException<InvalidOperationException>(() => serializer.Deserialize<Chalkboard>(stream));
         }
 
         [TestMethod]

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -167,6 +167,16 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void ExceptionOnMultiParameterIonPropertySetterMethods()
+        {
+            var serializer = new IonSerializer();
+            var chalkboard = new Chalkboard {width = 48, height = 36};
+
+            var stream = serializer.Serialize(chalkboard);
+            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Chalkboard>(stream));
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()
         {
             Check(

--- a/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonObjectSerializerTest.cs
@@ -143,6 +143,15 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
 
         [TestMethod]
+        public void DoesNotDoubleSerializeIonFieldsAlreadySerializedByMethods()
+        {
+            IIonStruct serialized = SerializeToIonValue(TestObjects.Ruler);
+
+            // We should have exactly two fields. ie. we did not double serialize the Ruler's length or unit members.
+            Assert.AreEqual(2, serialized.Count);
+        }
+
+        [TestMethod]
         public void ExceptionOnMultiParameterIonPropertySetterMethods()
         {
             var serializer = new IonSerializer();

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -152,6 +152,8 @@ namespace Amazon.Ion.ObjectMapper.Test
         public static School fieldAcademy = new School("1234 Fictional Ave", 150, new List<Teacher>(faculty));
         
         public static Student JohnGreenwood = new Student("John", "Greenwood", "Physics");
+        
+        public static Desk SchoolDesk = new Desk {width = 48, Depth = 24, Height = 30};
 
         private static Politician GeorgeAdams = new Politician {FirstName = "George", LastName = "Adams" };
         private static Politician SuzanneBenson = new Politician {FirstName = "Suzanne", LastName = "Benson" };
@@ -366,6 +368,30 @@ namespace Amazon.Ion.ObjectMapper.Test
         public override string ToString()
         {
             return $"<Student>{{ FirstName: {FirstName}, LastName: {LastName}, Major: {Major} }}";
+        }
+    }
+
+    public class Desk
+    {
+        public int width;
+        public int Depth { get; init; }
+        public int Height { get; init; }
+
+        [IonPropertyGetter("length")]
+        public int GetWidth() 
+        {
+            return this.width;
+        }
+        
+        [IonPropertySetter("length")]
+        public void SetWidth(int width) 
+        {
+            this.width = width;
+        }
+
+        public override string ToString()
+        {
+            return $"<Desk>{{ width: {width},  Depth: {Depth}, Height: {Height} }}";
         }
     }
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -401,6 +401,19 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
+    public class Chalkboard
+    {
+        public int width { get; set; }
+        public int height { get; set; }
+
+        [IonPropertySetter("width")]
+        public void SetSize(int width, int height)
+        {
+            this.width = width;
+            this.height = height;
+        }
+    }
+
     public class Country
     {
         public string Name { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -369,6 +369,36 @@ namespace Amazon.Ion.ObjectMapper.Test
         }
     }
 
+    public class Ruler
+    {
+        public int length { get; set; }
+        internal string unit;
+
+        [IonPropertyGetter("length")]
+        public int GetLength() 
+        {
+            return this.length + 10;
+        }
+
+        [IonPropertySetter("length")]
+        public void SetLength(int length) 
+        {
+            this.length = length - 10;
+        }
+        
+        [IonPropertyGetter("unit")]
+        public string GetUnit()
+        {
+            return this.unit == "cm" ? "centimeter" : this.unit;
+        }
+
+        [IonPropertySetter("unit")]
+        public void SetUnit(string unit)
+        {
+            this.unit = unit == "centimeter" ? "cm" : unit;
+        }
+    }
+
     public class Country
     {
         public string Name { get; init; }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -372,6 +372,8 @@ namespace Amazon.Ion.ObjectMapper.Test
     public class Ruler
     {
         public int length { get; set; }
+        
+        [IonField]
         internal string unit;
 
         [IonPropertyGetter("length")]

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -375,7 +375,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
     public class Desk
     {
-        public int width;
+        internal int width;
         public int Depth { get; init; }
         public int Height { get; init; }
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -155,6 +155,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static Desk SchoolDesk = new Desk {width = 48, Depth = 24, Height = 30};
         public static Ruler Ruler = new Ruler {length = 30, unit = "cm"};
+        public static Chalkboard Chalkboard = new Chalkboard {width = 48, height = 36};
 
         private static Politician GeorgeAdams = new Politician {FirstName = "George", LastName = "Adams" };
         private static Politician SuzanneBenson = new Politician {FirstName = "Suzanne", LastName = "Benson" };

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -154,6 +154,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         public static Student JohnGreenwood = new Student("John", "Greenwood", "Physics");
         
         public static Desk SchoolDesk = new Desk {width = 48, Depth = 24, Height = 30};
+        public static Ruler Ruler = new Ruler {length = 30, unit = "cm"};
 
         private static Politician GeorgeAdams = new Politician {FirstName = "George", LastName = "Adams" };
         private static Politician SuzanneBenson = new Politician {FirstName = "Suzanne", LastName = "Benson" };
@@ -405,25 +406,25 @@ namespace Amazon.Ion.ObjectMapper.Test
         [IonPropertyGetter("length")]
         public int GetLength() 
         {
-            return this.length + 10;
+            return this.length;
         }
 
         [IonPropertySetter("length")]
         public void SetLength(int length) 
         {
-            this.length = length - 10;
+            this.length = length;
         }
         
         [IonPropertyGetter("unit")]
         public string GetUnit()
         {
-            return this.unit == "cm" ? "centimeter" : this.unit;
+            return this.unit;
         }
 
         [IonPropertySetter("unit")]
         public void SetUnit(string unit)
         {
-            this.unit = unit == "centimeter" ? "cm" : unit;
+            this.unit = unit;
         }
     }
 

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -379,13 +379,13 @@ namespace Amazon.Ion.ObjectMapper.Test
         public int Depth { get; init; }
         public int Height { get; init; }
 
-        [IonPropertyGetter("length")]
+        [IonPropertyGetter("desk width")]
         public int GetWidth() 
         {
             return this.width;
         }
         
-        [IonPropertySetter("length")]
+        [IonPropertySetter("desk width")]
         public void SetWidth(int width) 
         {
             this.width = width;

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -96,7 +96,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             return IonLoader.Default.Load(stream).GetElementAt(0);
         }
-
+        
         public static IIonValue SerializeToIonWithCustomSerializer<T>(IonSerializer<T> customSerializer, T item)
         {
             return SerializeToIonWithCustomSerializers(

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -72,7 +72,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasAnnotation(string annotation, Stream stream)
         {
-            AssertHasAnnotation(annotation, StreamToIonValue(Copy(stream)));
+            AssertHasAnnotation(annotation, StreamToIonValue(stream));
         }
 
         public static void AssertHasAnnotation(string annotation, IIonValue ionValue)
@@ -83,7 +83,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasNoAnnotations(Stream stream)
         {
-            var count = StreamToIonValue(Copy(stream)).GetTypeAnnotationSymbols().Count;
+            var count = StreamToIonValue(stream).GetTypeAnnotationSymbols().Count;
             Assert.IsTrue(count == 0, "Has " + count + " annotations");
         }
 
@@ -94,7 +94,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static IIonValue StreamToIonValue(Stream stream)
         {
-            return IonLoader.Default.Load(stream).GetElementAt(0);
+            return IonLoader.Default.Load(Copy(stream)).GetElementAt(0);
         }
         
         public static IIonValue SerializeToIonWithCustomSerializer<T>(IonSerializer<T> customSerializer, T item)

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -97,12 +97,6 @@ namespace Amazon.Ion.ObjectMapper.Test
             return IonLoader.Default.Load(Copy(stream)).GetElementAt(0);
         }
 
-        public static IIonValue SerializeToIonValue(object item)
-        {
-            var stream = new IonSerializer().Serialize(item);
-            return StreamToIonValue(stream);
-        }
-        
         public static IIonValue SerializeToIonWithCustomSerializer<T>(IonSerializer<T> customSerializer, T item)
         {
             return SerializeToIonWithCustomSerializers(

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -72,7 +72,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasAnnotation(string annotation, Stream stream)
         {
-            AssertHasAnnotation(annotation, StreamToIonValue(stream));
+            AssertHasAnnotation(annotation, StreamToIonValue(Copy(stream)));
         }
 
         public static void AssertHasAnnotation(string annotation, IIonValue ionValue)
@@ -83,7 +83,7 @@ namespace Amazon.Ion.ObjectMapper.Test
 
         public static void AssertHasNoAnnotations(Stream stream)
         {
-            var count = StreamToIonValue(stream).GetTypeAnnotationSymbols().Count;
+            var count = StreamToIonValue(Copy(stream)).GetTypeAnnotationSymbols().Count;
             Assert.IsTrue(count == 0, "Has " + count + " annotations");
         }
 
@@ -94,7 +94,7 @@ namespace Amazon.Ion.ObjectMapper.Test
         
         public static IIonValue StreamToIonValue(Stream stream)
         {
-            return IonLoader.Default.Load(Copy(stream)).GetElementAt(0);
+            return IonLoader.Default.Load(stream).GetElementAt(0);
         }
 
         public static IIonValue SerializeToIonWithCustomSerializer<T>(IonSerializer<T> customSerializer, T item)

--- a/Amazon.Ion.ObjectMapper.Test/Utils.cs
+++ b/Amazon.Ion.ObjectMapper.Test/Utils.cs
@@ -96,6 +96,12 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             return IonLoader.Default.Load(Copy(stream)).GetElementAt(0);
         }
+
+        public static IIonValue SerializeToIonValue(object item)
+        {
+            var stream = new IonSerializer().Serialize(item);
+            return StreamToIonValue(stream);
+        }
         
         public static IIonValue SerializeToIonWithCustomSerializer<T>(IonSerializer<T> customSerializer, T item)
         {

--- a/Amazon.Ion.ObjectMapper/Attributes.cs
+++ b/Amazon.Ion.ObjectMapper/Attributes.cs
@@ -36,6 +36,43 @@ namespace Amazon.Ion.ObjectMapper
         public string Name { get; }
     }
 
+    /// <summary>
+    /// Attribute to identify a field/property's getter method to be used
+    /// during serialization of that field/property.
+    /// </summary>
+    public class IonPropertyGetter : Attribute
+    {
+        /// <summary>
+        /// Attribute constructor.
+        /// </summary>
+        public IonPropertyGetter(string fieldName)
+        {
+            this.FieldName = fieldName;
+        }
+
+        /// <summary>
+        /// The name of the field to be serialized with the getter method.
+        /// </summary>
+        public string FieldName { get; }
+    }
+
+    /// <summary>
+    /// Attribute to identify a field/property's setter method to be used
+    /// during deserialization of that field/property.
+    /// </summary>
+    public class IonPropertySetter : Attribute
+    {
+        public IonPropertySetter(string fieldName)
+        {
+            FieldName = fieldName;
+        }
+
+        /// <summary>
+        /// The name of the field to be deserialized with the setter method.
+        /// </summary>
+        public string FieldName { get; }
+    }
+
     public class IonField : Attribute
     {
     }

--- a/Amazon.Ion.ObjectMapper/Attributes.cs
+++ b/Amazon.Ion.ObjectMapper/Attributes.cs
@@ -37,40 +37,43 @@ namespace Amazon.Ion.ObjectMapper
     }
 
     /// <summary>
-    /// Attribute to identify a field/property's getter method to be used
-    /// during serialization of that field/property.
+    /// Attribute to identify an Ion property getter method to be used
+    /// during serialization of that Ion property.
     /// </summary>
     public class IonPropertyGetter : Attribute
     {
         /// <summary>
-        /// Attribute constructor.
+        /// IonPropertyGetter constructor.
         /// </summary>
-        public IonPropertyGetter(string fieldName)
+        public IonPropertyGetter(string ionPropertyName)
         {
-            this.FieldName = fieldName;
+            this.IonPropertyName = ionPropertyName;
         }
 
         /// <summary>
-        /// The name of the field to be serialized with the getter method.
+        /// The name of the Ion property to be serialized with the getter method.
         /// </summary>
-        public string FieldName { get; }
+        public string IonPropertyName { get; }
     }
 
     /// <summary>
-    /// Attribute to identify a field/property's setter method to be used
-    /// during deserialization of that field/property.
+    /// Attribute to identify an Ion property setter method to be used
+    /// during deserialization of that Ion property.
     /// </summary>
     public class IonPropertySetter : Attribute
     {
-        public IonPropertySetter(string fieldName)
+        /// <summary>
+        /// IonPropertySetter constructor.
+        /// </summary>
+        public IonPropertySetter(string ionPropertyName)
         {
-            FieldName = fieldName;
+            IonPropertyName = ionPropertyName;
         }
 
         /// <summary>
-        /// The name of the field to be deserialized with the setter method.
+        /// The name of the Ion property to be deserialized with the setter method.
         /// </summary>
-        public string FieldName { get; }
+        public string IonPropertyName { get; }
     }
 
     public class IonField : Attribute

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -107,16 +107,16 @@ namespace Amazon.Ion.ObjectMapper
                 var getMethod = (IonPropertyGetter)method.GetCustomAttribute(typeof(IonPropertyGetter));
                 
                 // A getter method should have zero parameters.
-                if (getMethod?.FieldName == null || method.GetParameters().Length != 0)
+                if (getMethod?.IonPropertyName == null || method.GetParameters().Length != 0)
                 {
                     continue;
                 }
 
-                writer.SetFieldName(getMethod.FieldName);
+                writer.SetFieldName(getMethod.IonPropertyName);
                 var getValue = method.Invoke(item, Array.Empty<object>());
                 ionSerializer.Serialize(writer, getValue);
                 
-                serializedWithGetter.Add(getMethod.FieldName);
+                serializedWithGetter.Add(getMethod.IonPropertyName);
             }
 
             // Serialize any properties that satisfy the options/attributes.
@@ -188,7 +188,7 @@ namespace Amazon.Ion.ObjectMapper
             return targetType.GetMethods().FirstOrDefault(m =>
             {
                 var setMethod = (IonPropertySetter)m.GetCustomAttribute(typeof(IonPropertySetter));
-                return setMethod != null && setMethod.FieldName == name;
+                return setMethod != null && setMethod.IonPropertyName == name;
             });
         }
 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -38,12 +38,6 @@ namespace Amazon.Ion.ObjectMapper
                 // Check if current Ion field has a IonPropertySetter annotated setter method.
                 if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
-                    // A setter should be a void method.
-                    if (method.ReturnParameter?.ParameterType != typeof(void))
-                    {
-                        continue;
-                    }
-
                     // A setter should have exactly one argument.
                     var parameters = method.GetParameters();
                     if (parameters.Length != 1)

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -39,7 +39,7 @@ namespace Amazon.Ion.ObjectMapper
                 if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
                     // A setter should be a void method.
-                    if (method.ReturnParameter == null || method.ReturnParameter.ParameterType != typeof(void))
+                    if (method.ReturnParameter?.ParameterType != typeof(void))
                     {
                         continue;
                     }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -42,7 +42,7 @@ namespace Amazon.Ion.ObjectMapper
                     var parameters = method.GetParameters();
                     if (parameters.Length != 1)
                     {
-                        throw new NotSupportedException(
+                        throw new InvalidOperationException(
                             "An [IonPropertySetter] annotated method should have exactly one argument " +
                             $"but {method.Name} has {parameters.Length} arguments");
                     }

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -52,10 +52,6 @@ namespace Amazon.Ion.ObjectMapper
                     }
 
                     var deserialized = ionSerializer.Deserialize(reader, parameters[0].ParameterType, ionType);
-                    if (options.IgnoreDefaults && deserialized == default)
-                    {
-                        continue;
-                    }
 
                     method.Invoke(targetObject, new[]{ deserialized });
                 }
@@ -118,14 +114,6 @@ namespace Amazon.Ion.ObjectMapper
                 }
 
                 var getValue = method.Invoke(item, Array.Empty<object>());
-                if (options.IgnoreNulls && getValue == null)
-                {
-                    continue;
-                }
-                if (options.IgnoreDefaults && getValue == default)
-                {
-                    continue;
-                }
                 
                 writer.SetFieldName(getMethod.IonPropertyName);
                 ionSerializer.Serialize(writer, getValue);

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -52,6 +52,11 @@ namespace Amazon.Ion.ObjectMapper
                     }
 
                     var deserialized = ionSerializer.Deserialize(reader, parameters[0].ParameterType, ionType);
+                    if (options.IgnoreDefaults && deserialized == default)
+                    {
+                        continue;
+                    }
+
                     method.Invoke(targetObject, new[]{ deserialized });
                 }
                 // Check if current Ion field is a .NET property.
@@ -112,8 +117,17 @@ namespace Amazon.Ion.ObjectMapper
                     continue;
                 }
 
-                writer.SetFieldName(getMethod.IonPropertyName);
                 var getValue = method.Invoke(item, Array.Empty<object>());
+                if (options.IgnoreNulls && getValue == null)
+                {
+                    continue;
+                }
+                if (options.IgnoreDefaults && getValue == default)
+                {
+                    continue;
+                }
+                
+                writer.SetFieldName(getMethod.IonPropertyName);
                 ionSerializer.Serialize(writer, getValue);
                 
                 serializedWithGetter.Add(getMethod.IonPropertyName);

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -104,7 +104,7 @@ namespace Amazon.Ion.ObjectMapper
             options.TypeAnnotator.Apply(options, writer, targetType);
             writer.StepIn(IonType.Struct);
 
-            var serializedWithGetter = new List<string>();
+            var serializedViaMethod = new HashSet<string>();
             
             // Serialize the values returned from IonPropertyGetter annotated getter methods.
             foreach (var method in targetType.GetMethods())
@@ -130,15 +130,15 @@ namespace Amazon.Ion.ObjectMapper
                 writer.SetFieldName(getMethod.IonPropertyName);
                 ionSerializer.Serialize(writer, getValue);
                 
-                serializedWithGetter.Add(getMethod.IonPropertyName);
+                serializedViaMethod.Add(getMethod.IonPropertyName);
             }
 
             // Serialize any properties that satisfy the options/attributes.
             foreach (var property in targetType.GetProperties())
             {
-                if (serializedWithGetter.Contains(property.Name))
+                if (serializedViaMethod.Contains(property.Name))
                 {
-                    // This property was already serialized using a getter method.
+                    // This property name was already serialized using an annotated method.
                     continue;
                 }
                 
@@ -169,9 +169,9 @@ namespace Amazon.Ion.ObjectMapper
             // Serialize any fields that satisfy the options/attributes.
             foreach (var field in Fields())
             {
-                if (serializedWithGetter.Contains(field.Name))
+                if (serializedViaMethod.Contains(field.Name))
                 {
-                    // This field was already serialized using a getter method.
+                    // This field name was already serialized using an annotated method.
                     continue;
                 }
                 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -42,7 +42,9 @@ namespace Amazon.Ion.ObjectMapper
                     var parameters = method.GetParameters();
                     if (parameters.Length != 1)
                     {
-                        continue;
+                        throw new NotSupportedException(
+                            "An [IonPropertySetter] annotated method should have exactly one argument " +
+                            $"but {method.Name} has {parameters.Length} arguments");
                     }
 
                     var deserialized = ionSerializer.Deserialize(reader, parameters[0].ParameterType, ionType);

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -136,9 +136,10 @@ namespace Amazon.Ion.ObjectMapper
             // Serialize any properties that satisfy the options/attributes.
             foreach (var property in targetType.GetProperties())
             {
-                if (serializedViaMethod.Contains(property.Name))
+                var ionPropertyName = IonFieldNameFromProperty(property);
+                if (serializedViaMethod.Contains(ionPropertyName))
                 {
-                    // This property name was already serialized using an annotated method.
+                    // This Ion property name was already serialized using an annotated method.
                     continue;
                 }
                 
@@ -162,16 +163,17 @@ namespace Amazon.Ion.ObjectMapper
                     continue;
                 }
 
-                writer.SetFieldName(IonFieldNameFromProperty(property));
+                writer.SetFieldName(ionPropertyName);
                 ionSerializer.Serialize(writer, propertyValue);
             }
 
             // Serialize any fields that satisfy the options/attributes.
             foreach (var field in Fields())
             {
-                if (serializedViaMethod.Contains(field.Name))
+                var ionFieldName = GetFieldName(field);
+                if (serializedViaMethod.Contains(ionFieldName))
                 {
-                    // This field name was already serialized using an annotated method.
+                    // This Ion field name was already serialized using an annotated method.
                     continue;
                 }
                 
@@ -190,7 +192,7 @@ namespace Amazon.Ion.ObjectMapper
                     continue;
                 }
 
-                writer.SetFieldName(GetFieldName(field));
+                writer.SetFieldName(ionFieldName);
                 ionSerializer.Serialize(writer, fieldValue);
             }
 

--- a/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonObjectSerializer.cs
@@ -104,7 +104,7 @@ namespace Amazon.Ion.ObjectMapper
             options.TypeAnnotator.Apply(options, writer, targetType);
             writer.StepIn(IonType.Struct);
 
-            var serializedViaMethod = new HashSet<string>();
+            var serializedIonFields = new HashSet<string>();
             
             // Serialize the values returned from IonPropertyGetter annotated getter methods.
             foreach (var method in targetType.GetMethods())
@@ -130,16 +130,16 @@ namespace Amazon.Ion.ObjectMapper
                 writer.SetFieldName(getMethod.IonPropertyName);
                 ionSerializer.Serialize(writer, getValue);
                 
-                serializedViaMethod.Add(getMethod.IonPropertyName);
+                serializedIonFields.Add(getMethod.IonPropertyName);
             }
 
             // Serialize any properties that satisfy the options/attributes.
             foreach (var property in targetType.GetProperties())
             {
                 var ionPropertyName = IonFieldNameFromProperty(property);
-                if (serializedViaMethod.Contains(ionPropertyName))
+                if (serializedIonFields.Contains(ionPropertyName))
                 {
-                    // This Ion property name was already serialized using an annotated method.
+                    // This Ion property name was already serialized.
                     continue;
                 }
                 
@@ -171,9 +171,9 @@ namespace Amazon.Ion.ObjectMapper
             foreach (var field in Fields())
             {
                 var ionFieldName = GetFieldName(field);
-                if (serializedViaMethod.Contains(ionFieldName))
+                if (serializedIonFields.Contains(ionFieldName))
                 {
-                    // This Ion field name was already serialized using an annotated method.
+                    // This Ion field name was already serialized.
                     continue;
                 }
                 


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/10.

By default, C# methods are ignored, however, provided the “get” signature is a no-argument method and the “set” signature is a one-argument void method, methods can be use to get and set properties. The Ion property name must be specified and will not be inferred from the method name.

```c#
public class Car
{
    private string color;
    
    [IonPropertyGetter("color")]
    public string GetColor() 
    {
        return "#FF0000";
    }
    
    [IonPropertySetter("color")]
    public void SetColor(string input) 
    {
        this.color = input;
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
