### PR TITLE
Implement IonDictionarySerializer

### DIFF
--- a/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
+++ b/Amazon.Ion.ObjectMapper.Test/IonSerializerTest.cs
@@ -36,5 +36,16 @@ namespace Amazon.Ion.ObjectMapper.Test
         {
             Check(new int[] { 1, 1, 2, 3, 5, 8, 11 });
         }
+
+        [TestMethod]
+        public void SerializesAndDeserializesDictionaries()
+        {
+            var dictionary = new TestDictionary();
+            dictionary.Add("one", 1);
+            dictionary.Add("two", 2);
+            dictionary.Add("three", 3);
+            Assert.AreEqual(TestDictionary.PrettyString(dictionary), 
+                TestDictionary.PrettyString(Serde<Dictionary<string, int>>(dictionary)));
+        }
     }
 }

--- a/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
+++ b/Amazon.Ion.ObjectMapper.Test/TestObjects.cs
@@ -395,4 +395,12 @@ namespace Amazon.Ion.ObjectMapper.Test
         public string FirstName { get; init; }
         public string LastName { get; init; }
     }
+
+    public class TestDictionary : Dictionary<string, int>
+    {
+        public static string PrettyString(IDictionary<string, int> dictionary)
+        {
+            return string.Join(Environment.NewLine, dictionary);
+        }
+    }
 }

--- a/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
@@ -1,22 +1,52 @@
-﻿using Amazon.IonDotnet;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 namespace Amazon.Ion.ObjectMapper
 {
+    using Amazon.IonDotnet;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Reflection;
+
     public class IonDictionarySerializer : IonSerializer<IDictionary>
     {
-        private IonSerializer serializer;
-        private Type valueType;
+        private readonly IonSerializer serializer;
+        private readonly Type valueType;
 
+        /// <summary>
+        /// Initializes a new instance of an <see cref="IonDictionarySerializer"/>.
+        /// </summary>
+        ///
+        /// <param name="ionSerializer">
+        /// The Ion serializer to use for serializing and deserializing the values of the IDictionary.
+        /// </param>
+        /// <param name="valueType">
+        /// The Type of the Value of the IDictionary.
+        /// </param>
         public IonDictionarySerializer(IonSerializer ionSerializer, Type valueType)
         {
             this.serializer = ionSerializer;
             this.valueType = valueType;
         }
 
+        /// <summary>
+        /// Deserialize an Ion Struct into an IDictionary.
+        /// </summary>
+        /// 
+        /// <returns>
+        /// A Dictionary of Key Type string and Value Type valueType.
+        /// </returns>
         public override IDictionary Deserialize(IIonReader reader)
         {
             reader.StepIn();
@@ -27,9 +57,11 @@ namespace Amazon.Ion.ObjectMapper
             IonType currentType;
             while ((currentType = reader.MoveNext()) != IonType.None)
             {
-                object[] parameters = new object[] { 
+                object[] parameters = new object[] 
+                { 
                     reader.CurrentFieldName, 
-                    Convert.ChangeType(this.serializer.Deserialize(reader, valueType, currentType), valueType) };
+                    Convert.ChangeType(this.serializer.Deserialize(reader, valueType, currentType), valueType) 
+                };
                 methodInfo.Invoke(dictionary, parameters);
 
             }
@@ -38,10 +70,22 @@ namespace Amazon.Ion.ObjectMapper
             return (IDictionary)dictionary;
         }
 
+        /// <summary>
+        /// Serializes an IDictionary into an Ion Struct where the Key is the struct field name
+        /// and the Value is the struct field value.
+        /// </summary>
+        /// 
+        /// <param name="writer">
+        /// The IIonWriter to use to write the Ion Struct.
+        /// </param>
+        /// <param name="item">
+        /// The IDictionary to serialize into an Ion Struct.
+        /// </param>
         public override void Serialize(IIonWriter writer, IDictionary item)
         {
             writer.StepIn(IonType.Struct);
-            foreach (DictionaryEntry nameValuePair in item) {
+            foreach (DictionaryEntry nameValuePair in item) 
+            {
                 writer.SetFieldName((string)nameValuePair.Key);
                 this.serializer.Serialize(writer, nameValuePair.Value);
             }

--- a/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
@@ -1,0 +1,52 @@
+﻿using Amazon.IonDotnet;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Amazon.Ion.ObjectMapper
+{
+    public class IonDictionarySerializer : IonSerializer<IDictionary>
+    {
+        private IonSerializer serializer;
+        private Type valueType;
+
+        public IonDictionarySerializer(IonSerializer ionSerializer, Type valueType)
+        {
+            this.serializer = ionSerializer;
+            this.valueType = valueType;
+        }
+
+        public override IDictionary Deserialize(IIonReader reader)
+        {
+            reader.StepIn();
+
+            Type typedDictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), this.valueType);
+            MethodInfo methodInfo = typedDictionaryType.GetMethod("Add");
+            var dictionary = Activator.CreateInstance(typedDictionaryType);
+            IonType currentType;
+            while ((currentType = reader.MoveNext()) != IonType.None)
+            {
+                object[] parameters = new object[] { 
+                    reader.CurrentFieldName, 
+                    Convert.ChangeType(this.serializer.Deserialize(reader, valueType, currentType), valueType) };
+                methodInfo.Invoke(dictionary, parameters);
+
+            }
+
+            reader.StepOut();
+            return (IDictionary)dictionary;
+        }
+
+        public override void Serialize(IIonWriter writer, IDictionary item)
+        {
+            writer.StepIn(IonType.Struct);
+            foreach (DictionaryEntry nameValuePair in item) {
+                writer.SetFieldName((string)nameValuePair.Key);
+                this.serializer.Serialize(writer, nameValuePair.Value);
+            }
+
+            writer.StepOut();
+        }
+    }
+}

--- a/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
+++ b/Amazon.Ion.ObjectMapper/IonDictionarySerializer.cs
@@ -17,7 +17,6 @@ namespace Amazon.Ion.ObjectMapper
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Reflection;
 
     public class IonDictionarySerializer : IonSerializer<IDictionary>
     {
@@ -52,22 +51,15 @@ namespace Amazon.Ion.ObjectMapper
             reader.StepIn();
 
             Type typedDictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), this.valueType);
-            MethodInfo methodInfo = typedDictionaryType.GetMethod("Add");
-            var dictionary = Activator.CreateInstance(typedDictionaryType);
+            var dictionary = (IDictionary)Activator.CreateInstance(typedDictionaryType);
             IonType currentType;
             while ((currentType = reader.MoveNext()) != IonType.None)
             {
-                object[] parameters = new object[] 
-                { 
-                    reader.CurrentFieldName, 
-                    Convert.ChangeType(this.serializer.Deserialize(reader, valueType, currentType), valueType) 
-                };
-                methodInfo.Invoke(dictionary, parameters);
-
+                dictionary.Add(reader.CurrentFieldName, this.serializer.Deserialize(reader, valueType, currentType));
             }
 
             reader.StepOut();
-            return (IDictionary)dictionary;
+            return dictionary;
         }
 
         /// <summary>


### PR DESCRIPTION
Added serialization and deserialization support for dictionaries.

Serialization supports any C# types which implement the `IDictionary<String, V>` interface.

Deserialization from Ion Structs will deserialize into a `Dictionary<String, V>` as long as the specified type to deserialize into can be assigned from `Dictionary<String, V>`.

```
IDictionary dictionary = new Dictionary<string, int>();
dictionary.Add("one", 1);
dictionary.Add("two", 2);
dictionary.Add("three", 3;

var ionSerializer = new IonSerializer();

// Dictionaries can serialize into Ion Structs 
// {
//   one: 1,
//   two: 2,
//   three: 3,
// }
var serialized = ionSerializer.Serialize(dictionary);

// Ion Structs can be deserialized into Dictionary<string, T> types
Dictionary<string, int> deserialized = ionSerializer.Deserialize<Dictionary<string, int>>(serialized);
```