### PR TITLE
Implement custom constructor functionality

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -177,7 +177,7 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void ExceptionOnDeserializingObjectWithMultipleIonConstructors()
         {
-            var stream = defaultSerializer.Serialize(new Tire("default", 17));
+            var stream = defaultSerializer.Serialize(new Tire("default", "MSW"));
             Assert.ThrowsException<InvalidOperationException>(() => defaultSerializer.Deserialize<Tire>(stream));
         }
 

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -180,6 +180,13 @@ namespace Amazon.IonObjectMapper.Test
             var stream = defaultSerializer.Serialize(new Tire("default", "MSW"));
             Assert.ThrowsException<InvalidOperationException>(() => defaultSerializer.Deserialize<Tire>(stream));
         }
+        
+        [TestMethod]
+        public void ExceptionOnDeserializingObjectWithUnannotatedIonConstructorParameter()
+        {
+            var stream = defaultSerializer.Serialize(new Windshield(59, 31.5));
+            Assert.ThrowsException<InvalidOperationException>(() => defaultSerializer.Deserialize<Windshield>(stream));
+        }
 
         [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -173,6 +173,17 @@ namespace Amazon.IonObjectMapper.Test
         {
             Check(new Wheel("default", "MSW"));
         }
+        
+        [TestMethod]
+        public void CanDeserializeToDifferentTypeUsingIonConstructor()
+        {
+            var cr = new CircleRadius(5);
+            
+            var stream = defaultSerializer.Serialize(cr);
+            var cc = defaultSerializer.Deserialize<CircleCircumference>(stream);
+            
+            Assert.AreEqual(2 * Math.PI * cr.Radius, cc.Circumference);
+        }
 
         [TestMethod]
         public void ExceptionOnDeserializingObjectWithMultipleIonConstructors()

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -176,6 +176,7 @@ namespace Amazon.IonObjectMapper.Test
             var stream = defaultSerializer.Serialize(wheel);
             var deserialized = defaultSerializer.Deserialize<Wheel>(stream);
 
+            // Verify custom IonConstructor was used and remaining properties/fields were set after construction.
             Assert.AreEqual(
                 $"Specification: {wheel.Specification}, Size: {wheel.Size} inches", deserialized.Specification);
             Assert.AreEqual(wheel.offset, deserialized.offset);

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -171,17 +171,7 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void DeserializesObjectsWithIonConstructor()
         {
-            var wheel = new Wheel("default", 17, 20, "MSW", "black");
-
-            var stream = defaultSerializer.Serialize(wheel);
-            var deserialized = defaultSerializer.Deserialize<Wheel>(stream);
-
-            // Verify custom IonConstructor was used and remaining properties/fields were set after construction.
-            Assert.AreEqual(
-                $"Specification: {wheel.Specification}, Size: {wheel.Size} inches", deserialized.Specification);
-            Assert.AreEqual(wheel.offset, deserialized.offset);
-            Assert.AreEqual(wheel.Brand, deserialized.Brand);
-            Assert.AreEqual(wheel.color, deserialized.color);
+            Check(new Wheel("default", "MSW"));
         }
 
         [TestMethod]

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -169,6 +169,31 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
+        public void SerializesAndDeserializesObjectsWithIonConstructor()
+        {
+            var serializer = new IonSerializer();
+            var wheel = new Wheel("default", 17, "MSW", "black");
+
+            var stream = serializer.Serialize(wheel);
+            var deserialized = serializer.Deserialize<Wheel>(stream);
+
+            Assert.AreEqual(
+                $"Specification: {wheel.Specification}, Size: {wheel.Size} inches", deserialized.Specification);
+            Assert.AreEqual(wheel.Brand, deserialized.Brand);
+            Assert.AreEqual(wheel.color, deserialized.color);
+        }
+
+        [TestMethod]
+        public void ExceptionOnDeserializingObjectWithMultipleIonConstructors()
+        {
+            var serializer = new IonSerializer();
+            var tire = new Tire("default", 17);
+
+            var stream = serializer.Serialize(tire);
+            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Tire>(stream));
+        }
+
+        [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()
         {
             Check(

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -172,13 +172,14 @@ namespace Amazon.IonObjectMapper.Test
         public void SerializesAndDeserializesObjectsWithIonConstructor()
         {
             var serializer = new IonSerializer();
-            var wheel = new Wheel("default", 17, "MSW", "black");
+            var wheel = new Wheel("default", 17, 20, "MSW", "black");
 
             var stream = serializer.Serialize(wheel);
             var deserialized = serializer.Deserialize<Wheel>(stream);
 
             Assert.AreEqual(
                 $"Specification: {wheel.Specification}, Size: {wheel.Size} inches", deserialized.Specification);
+            Assert.AreEqual(wheel.offset, deserialized.offset);
             Assert.AreEqual(wheel.Brand, deserialized.Brand);
             Assert.AreEqual(wheel.color, deserialized.color);
         }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -187,11 +187,8 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void ExceptionOnDeserializingObjectWithMultipleIonConstructors()
         {
-            var serializer = new IonSerializer();
-            var tire = new Tire("default", 17);
-
-            var stream = serializer.Serialize(tire);
-            Assert.ThrowsException<NotSupportedException>(() => serializer.Deserialize<Tire>(stream));
+            var stream = defaultSerializer.Serialize(new Tire("default", 17));
+            Assert.ThrowsException<InvalidOperationException>(() => defaultSerializer.Deserialize<Tire>(stream));
         }
 
         [TestMethod]

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -169,13 +169,12 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void SerializesAndDeserializesObjectsWithIonConstructor()
+        public void DeserializesObjectsWithIonConstructor()
         {
-            var serializer = new IonSerializer();
             var wheel = new Wheel("default", 17, 20, "MSW", "black");
 
-            var stream = serializer.Serialize(wheel);
-            var deserialized = serializer.Deserialize<Wheel>(stream);
+            var stream = defaultSerializer.Serialize(wheel);
+            var deserialized = defaultSerializer.Deserialize<Wheel>(stream);
 
             Assert.AreEqual(
                 $"Specification: {wheel.Specification}, Size: {wheel.Size} inches", deserialized.Specification);

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -346,6 +346,31 @@ namespace Amazon.IonObjectMapper.Test
         }
     }
 
+    // For testing serializing and deserializing between different types using an annotated constructor.
+    public class CircleRadius
+    {
+        public double Radius { get; init; }
+        
+        public CircleRadius(double radius)
+        {
+            this.Radius = radius;
+        }
+    }
+
+    // For testing serializing and deserializing between different types using an annotated constructor.
+    // We serialize a CircleRadius and then use the deserialized radius with the annotated constructor
+    // to create a CircleCircumference.
+    public class CircleCircumference
+    {
+        public double Circumference { get; init; }
+
+        [IonConstructor]
+        public CircleCircumference([IonPropertyName("radius")] double radius)
+        {
+            this.Circumference = 2 * Math.PI * radius;
+        }
+    }
+
     public class School
     {
         private readonly string address;

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -294,16 +294,17 @@ namespace Amazon.IonObjectMapper.Test
     {
         public string Specification { get; init; }
         public int Size { get; init; }
-        
         public string Brand { get; init; }
 
         [IonField]
         internal string color;
+        internal int offset;
 
-        public Wheel(string specification, int size, string brand, string color)
+        public Wheel(string specification, int size, int offset, string brand, string color)
         {
             this.Specification = specification;
             this.Size = size;
+            this.offset = offset;
             this.Brand = brand;
             this.color = color;
         }
@@ -315,6 +316,18 @@ namespace Amazon.IonObjectMapper.Test
         {
             this.Specification = $"Specification: {specification}, Size: {size} inches";
             this.Size = size;
+        }
+        
+        [IonPropertyGetter("wheel offset")]
+        public int GetOffset() 
+        {
+            return this.offset;
+        }
+        
+        [IonPropertySetter("wheel offset")]
+        public void SetOffset(int offset) 
+        {
+            this.offset = offset;
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -293,20 +293,20 @@ namespace Amazon.IonObjectMapper.Test
     public class Wheel
     {
         public string Brand { get; init; }
-        public string specification { get; init; }
+        public string Specification { get; init; }
 
         [IonConstructor]
         public Wheel(
             [IonPropertyName("specification")] string specification,
             [IonPropertyName("brand")] string brand)
         {
-            this.specification = specification;
+            this.Specification = specification;
             this.Brand = brand;
         }
 
         public override string ToString()
         {
-            return $"<Wheel>{{ Specification: {specification}, Brand: {Brand} }}";
+            return $"<Wheel>{{ Specification: {Specification}, Brand: {Brand} }}";
         }
     }
 
@@ -314,21 +314,21 @@ namespace Amazon.IonObjectMapper.Test
     public class Tire
     {
         public string Brand { get; init; }
-        public string specification { get; init; }
+        public string Specification { get; init; }
 
         [IonConstructor]
         public Tire(
             [IonPropertyName("specification")] string specification,
             [IonPropertyName("brand")] string brand)
         {
-            this.specification = specification;
+            this.Specification = specification;
             this.Brand = brand;
         }
 
         [IonConstructor]
         private Tire([IonPropertyName("specification")] string specification)
         {
-            this.specification = specification;
+            this.Specification = specification;
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -292,42 +292,23 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Wheel
     {
-        public string Specification { get; init; }
-        public int Size { get; init; }
         public string Brand { get; init; }
 
         [IonField]
-        internal string color;
-        internal int offset;
-
-        public Wheel(string specification, int size, int offset, string brand, string color)
-        {
-            this.Specification = specification;
-            this.Size = size;
-            this.offset = offset;
-            this.Brand = brand;
-            this.color = color;
-        }
+        private string specification;
 
         [IonConstructor]
-        private Wheel(
+        public Wheel(
             [IonPropertyName("specification")] string specification,
-            [IonPropertyName("size")] int size)
+            [IonPropertyName("brand")] string brand)
         {
-            this.Specification = $"Specification: {specification}, Size: {size} inches";
-            this.Size = size;
+            this.specification = specification;
+            this.Brand = brand;
         }
-        
-        [IonPropertyGetter("wheel offset")]
-        public int GetOffset() 
+
+        public override string ToString()
         {
-            return this.offset;
-        }
-        
-        [IonPropertySetter("wheel offset")]
-        public void SetOffset(int offset) 
-        {
-            this.offset = offset;
+            return $"<Wheel>{{ Specification: {specification}, Brand: {Brand} }}";
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -312,25 +312,27 @@ namespace Amazon.IonObjectMapper.Test
         }
     }
 
+    // For testing multiple annotated constructors.
     public class Tire
     {
-        public string specification { get; init; }
-        public int size { get; init; }
+        public string Brand { get; init; }
+
+        [IonField]
+        private string specification;
 
         [IonConstructor]
-        public Tire(string specification, int size)
+        public Tire(
+            [IonPropertyName("specification")] string specification,
+            [IonPropertyName("brand")] string brand)
         {
             this.specification = specification;
-            this.size = size;
+            this.Brand = brand;
         }
 
         [IonConstructor]
-        private Tire(
-            [IonPropertyName("size")] int size,
-            [IonPropertyName("specification")] string specification)
+        private Tire([IonPropertyName("specification")] string specification)
         {
-            this.specification = $"Specification: {specification}, Size: {size} inches";
-            this.size = size;
+            this.specification = specification;
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -292,10 +292,51 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Wheel
     {
-        [IonConstructor]
-        public Wheel([IonPropertyName("specification")] string specification)
-        {
+        public string Specification { get; init; }
+        public int Size { get; init; }
+        
+        public string Brand { get; init; }
 
+        [IonField]
+        internal string color;
+
+        public Wheel(string specification, int size, string brand, string color)
+        {
+            this.Specification = specification;
+            this.Size = size;
+            this.Brand = brand;
+            this.color = color;
+        }
+
+        [IonConstructor]
+        private Wheel(
+            [IonPropertyName("specification")] string specification,
+            [IonPropertyName("size")] int size)
+        {
+            this.Specification = $"Specification: {specification}, Size: {size} inches";
+            this.Size = size;
+        }
+    }
+
+    public class Tire
+    {
+        public string specification { get; init; }
+        public int size { get; init; }
+
+        [IonConstructor]
+        public Tire(string specification, int size)
+        {
+            this.specification = specification;
+            this.size = size;
+        }
+
+        [IonConstructor]
+        private Tire(
+            [IonPropertyName("size")] int size,
+            [IonPropertyName("specification")] string specification)
+        {
+            this.specification = $"Specification: {specification}, Size: {size} inches";
+            this.size = size;
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -293,9 +293,7 @@ namespace Amazon.IonObjectMapper.Test
     public class Wheel
     {
         public string Brand { get; init; }
-
-        [IonField]
-        private string specification;
+        public string specification { get; init; }
 
         [IonConstructor]
         public Wheel(
@@ -316,9 +314,7 @@ namespace Amazon.IonObjectMapper.Test
     public class Tire
     {
         public string Brand { get; init; }
-
-        [IonField]
-        private string specification;
+        public string specification { get; init; }
 
         [IonConstructor]
         public Tire(

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -332,6 +332,20 @@ namespace Amazon.IonObjectMapper.Test
         }
     }
 
+    // For testing unannotated constructor parameters.
+    public class Windshield
+    {
+        public double Length { get; init; }
+        public double Height { get; init; } 
+        
+        [IonConstructor]
+        public Windshield(double length, double height)
+        {
+            this.Length = length;
+            this.Height = height;
+        }
+    }
+
     public class School
     {
         private readonly string address;

--- a/Amazon.IonObjectMapper/Attributes.cs
+++ b/Amazon.IonObjectMapper/Attributes.cs
@@ -22,6 +22,10 @@ namespace Amazon.IonObjectMapper
     {
     }
 
+    /// <summary>
+    /// Attribute to identify a custom constructor to be used to instantiate instances
+    /// of the class annotated with this attribute during deserialization.
+    /// </summary>
     public class IonConstructor : Attribute
     {
     }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -173,6 +173,8 @@ namespace Amazon.IonObjectMapper
 
         private bool TryDeserializeProperty(PropertyInfo property, IIonReader reader, IonType ionType, ref object deserialized)
         {
+            deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
+            
             if (IsReadOnlyProperty(property))
             {
                 // property.SetValue() does not work with a readonly property.
@@ -180,8 +182,6 @@ namespace Amazon.IonObjectMapper
                 // when we detect backing fields for the property.
                 return false;
             }
-
-            deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
 
             return !options.IgnoreDefaults || deserialized != default;
         }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -101,7 +101,11 @@ namespace Amazon.IonObjectMapper
                 if (constructorArgIndexMap != null && constructorArgIndexMap.ContainsKey(reader.CurrentFieldName))
                 {
                     var index = constructorArgIndexMap[reader.CurrentFieldName];
+                    
+                    // Deserialize current Ion field only if it was not already
+                    // deserialized by the above method/property/field logic.
                     deserialized ??= ionSerializer.Deserialize(reader, parameters[index].ParameterType, ionType);
+                    
                     constructorArgs[index] = deserialized;
                 }
             }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -30,7 +30,7 @@ namespace Amazon.IonObjectMapper
             {
                 if (ionConstructors.Count() > 1)
                 {
-                    throw new NotSupportedException(
+                    throw new InvalidOperationException(
                         $"Only one constructor in class {targetType.Name} may be annotated " +
                         "with the [IonConstructor] attribute and more than one was detected");
                 }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -291,7 +291,7 @@ namespace Amazon.IonObjectMapper
                 var ionPropertyName = (IonPropertyName)parameters[i].GetCustomAttribute(typeof(IonPropertyName));
                 if (ionPropertyName == null)
                 {
-                    throw new NotSupportedException(
+                    throw new InvalidOperationException(
                         $"Parameter '{parameters[i].Name}' is not specified with the [IonPropertyName] attribute " +
                         $"for {targetType.Name}'s IonConstructor. All constructor arguments must be annotated " +
                         "so we know which parameters to set at construction time.");

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -240,7 +240,7 @@ namespace Amazon.IonObjectMapper
 
             // Deserialize Ion and organize deserialized results into four categories:
             // 1. Values to be passed into the Ion constructor.
-            // 2. Values to be set via annotated setters after construction.
+            // 2. Values to be set via annotated methods after construction.
             // 3. Properties to be set after construction.
             // 4. Fields to be set after construction.
             var constructorArgs = new object[parameters.Length];
@@ -289,7 +289,7 @@ namespace Amazon.IonObjectMapper
 
             var targetObject = ionConstructor.Invoke(constructorArgs);
 
-            // Set values with annotated setters.
+            // Set values with annotated methods.
             foreach (var (method, deserialized) in setterMethods)
             {
                 method.Invoke(targetObject, new[]{ deserialized });

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -68,7 +68,7 @@ namespace Amazon.IonObjectMapper
                 else if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = new object();
-                    if (this.DeserializeProperty(property, reader, ionType, ref deserialized))
+                    if (this.TryDeserializeProperty(property, reader, ionType, ref deserialized))
                     {
                         property.SetValue(targetObject, deserialized);
                     }
@@ -77,7 +77,7 @@ namespace Amazon.IonObjectMapper
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = new object();
-                    if (this.DeserializeField(field, reader, ionType, ref deserialized))
+                    if (this.TryDeserializeField(field, reader, ionType, ref deserialized))
                     {
                         field.SetValue(targetObject, deserialized);
                     }
@@ -171,7 +171,7 @@ namespace Amazon.IonObjectMapper
             writer.StepOut();
         }
 
-        private bool DeserializeProperty(PropertyInfo property, IIonReader reader, IonType ionType, ref object deserialized)
+        private bool TryDeserializeProperty(PropertyInfo property, IIonReader reader, IonType ionType, ref object deserialized)
         {
             if (IsReadOnlyProperty(property))
             {
@@ -190,7 +190,7 @@ namespace Amazon.IonObjectMapper
             return true;
         }
         
-        private bool DeserializeField(FieldInfo field, IIonReader reader, IonType ionType, ref object deserialized)
+        private bool TryDeserializeField(FieldInfo field, IIonReader reader, IonType ionType, ref object deserialized)
         {
             deserialized = ionSerializer.Deserialize(reader, field.FieldType, ionType);
             
@@ -251,7 +251,7 @@ namespace Amazon.IonObjectMapper
                 else if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = new object();
-                    if (this.DeserializeProperty(property, reader, ionType, ref deserialized))
+                    if (this.TryDeserializeProperty(property, reader, ionType, ref deserialized))
                     {
                         remainingProperties.Add((property, deserialized));
                     }
@@ -259,7 +259,7 @@ namespace Amazon.IonObjectMapper
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
                     var deserialized = new object();
-                    if (this.DeserializeField(field, reader, ionType, ref deserialized))
+                    if (this.TryDeserializeField(field, reader, ionType, ref deserialized))
                     {
                         remainingFields.Add((field, deserialized));
                     }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -25,7 +25,7 @@ namespace Amazon.IonObjectMapper
 
         public override object Deserialize(IIonReader reader)
         {
-            var ionConstructors = targetType.GetConstructors(BINDINGS).Where(IsIonConstructor);
+            var ionConstructors = targetType.GetConstructors(BINDINGS).Where(IsIonConstructor).Take(2);
             if (ionConstructors.Any())
             {
                 if (ionConstructors.Count() > 1)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -71,11 +71,13 @@ namespace Amazon.IonObjectMapper
                 PropertyInfo property;
                 FieldInfo field;
                 object deserialized = null;
+                bool isDeserialized = false;
 
                 // Check if current Ion field has an annotated method.
                 if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
-                    if (this.TryDeserializeMethod(method, reader, ionType, out deserialized))
+                    isDeserialized = this.TryDeserializeMethod(method, reader, ionType, out deserialized);
+                    if (isDeserialized)
                     {
                         deserializedMethods.Add((method, deserialized));
                     }
@@ -83,7 +85,8 @@ namespace Amazon.IonObjectMapper
                 // Check if current Ion field is a .NET property.
                 else if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
-                    if (this.TryDeserializeProperty(property, reader, ionType, out deserialized))
+                    isDeserialized = this.TryDeserializeProperty(property, reader, ionType, out deserialized);
+                    if (isDeserialized)
                     {
                         deserializedProperties.Add((property, deserialized));
                     }
@@ -91,7 +94,8 @@ namespace Amazon.IonObjectMapper
                 // Check if current Ion field is a .NET field.
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
-                    if (this.TryDeserializeField(field, reader, ionType, out deserialized))
+                    isDeserialized = this.TryDeserializeField(field, reader, ionType, out deserialized);
+                    if (isDeserialized)
                     {
                         deserializedFields.Add((field, deserialized));
                     }
@@ -104,7 +108,10 @@ namespace Amazon.IonObjectMapper
                     
                     // Deserialize current Ion field only if it was not already
                     // deserialized by the above method/property/field logic.
-                    deserialized ??= ionSerializer.Deserialize(reader, parameters[index].ParameterType, ionType);
+                    if (!isDeserialized)
+                    {
+                        deserialized = ionSerializer.Deserialize(reader, parameters[index].ParameterType, ionType);
+                    }
                     
                     constructorArgs[index] = deserialized;
                 }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -182,12 +182,8 @@ namespace Amazon.IonObjectMapper
             }
 
             deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
-            if (options.IgnoreDefaults && deserialized == default)
-            {
-                return false;
-            }
 
-            return true;
+            return !options.IgnoreDefaults || deserialized != default;
         }
         
         private bool TryDeserializeField(FieldInfo field, IIonReader reader, IonType ionType, ref object deserialized)
@@ -198,13 +194,8 @@ namespace Amazon.IonObjectMapper
             {
                 return false;
             }
-            
-            if (options.IgnoreDefaults && deserialized == default)
-            {
-                return false;
-            }
 
-            return true;
+            return !options.IgnoreDefaults || deserialized != default;
         }
 
         private object DeserializeWithIonConstructor(ConstructorInfo ionConstructor, IIonReader reader)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -171,8 +171,12 @@ namespace Amazon.IonObjectMapper
             writer.StepOut();
         }
 
-        private bool TryDeserializeProperty(PropertyInfo property, IIonReader reader, IonType ionType, ref object deserialized)
+        // Deserialize the given property and return bool to indicate whether the deserialized result should be used.
+        private bool TryDeserializeProperty(
+            PropertyInfo property, IIonReader reader, IonType ionType, ref object deserialized)
         {
+            // We deserialize whether or not we ultimately use the result because values
+            // for some Ion types need to be consumed in order to advance the reader.
             deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
             
             if (IsReadOnlyProperty(property))
@@ -186,8 +190,11 @@ namespace Amazon.IonObjectMapper
             return !options.IgnoreDefaults || deserialized != default;
         }
         
+        // Deserialize the given field and return bool to indicate whether the deserialized result should be used.
         private bool TryDeserializeField(FieldInfo field, IIonReader reader, IonType ionType, ref object deserialized)
         {
+            // We deserialize whether or not we ultimately use the result because values
+            // for some Ion types need to be consumed in order to advance the reader.
             deserialized = ionSerializer.Deserialize(reader, field.FieldType, ionType);
             
             if (options.IgnoreReadOnlyFields && field.IsInitOnly)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -71,34 +71,34 @@ namespace Amazon.IonObjectMapper
                 PropertyInfo property;
                 FieldInfo field;
                 object deserialized = null;
-                bool isDeserialized = false;
+                bool currentIonFieldProcessed = false;
 
                 // Check if current Ion field has an annotated method.
                 if ((method = FindSetter(reader.CurrentFieldName)) != null)
                 {
-                    isDeserialized = this.TryDeserializeMethod(method, reader, ionType, out deserialized);
-                    if (isDeserialized)
+                    if (this.TryDeserializeMethod(method, reader, ionType, out deserialized))
                     {
                         deserializedMethods.Add((method, deserialized));
                     }
+                    currentIonFieldProcessed = true;
                 }
                 // Check if current Ion field is a .NET property.
                 else if ((property = FindProperty(reader.CurrentFieldName)) != null)
                 {
-                    isDeserialized = this.TryDeserializeProperty(property, reader, ionType, out deserialized);
-                    if (isDeserialized)
+                    if (this.TryDeserializeProperty(property, reader, ionType, out deserialized))
                     {
                         deserializedProperties.Add((property, deserialized));
                     }
+                    currentIonFieldProcessed = true;
                 }
                 // Check if current Ion field is a .NET field.
                 else if ((field = FindField(reader.CurrentFieldName)) != null)
                 {
-                    isDeserialized = this.TryDeserializeField(field, reader, ionType, out deserialized);
-                    if (isDeserialized)
+                    if (this.TryDeserializeField(field, reader, ionType, out deserialized))
                     {
                         deserializedFields.Add((field, deserialized));
                     }
+                    currentIonFieldProcessed = true;
                 }
                 
                 // Check if current Ion field is also an argument for an annotated constructor.
@@ -107,8 +107,8 @@ namespace Amazon.IonObjectMapper
                     var index = constructorArgIndexMap[reader.CurrentFieldName];
                     
                     // Deserialize current Ion field only if it was not already
-                    // deserialized by the above method/property/field logic.
-                    if (!isDeserialized)
+                    // processed by the above method/property/field logic.
+                    if (!currentIonFieldProcessed)
                     {
                         deserialized = ionSerializer.Deserialize(reader, parameters[index].ParameterType, ionType);
                     }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -171,7 +171,7 @@ namespace Amazon.IonObjectMapper
             var parameters = method.GetParameters();
             if (parameters.Length != 1)
             {
-                throw new NotSupportedException(
+                throw new InvalidOperationException(
                     "An [IonPropertySetter] annotated method should have exactly one argument " +
                     $"but {method.Name} has {parameters.Length} arguments");
             }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -31,8 +31,8 @@ namespace Amazon.IonObjectMapper
                 if (ionConstructors.Count() > 1)
                 {
                     throw new NotSupportedException(
-                        $"More than one constructor in class {targetType.Name} " +
-                        "is annotated with the [IonConstructor] attribute");
+                        $"Only one constructor in class {targetType.Name} may be annotated " +
+                        "with the [IonConstructor] attribute and more than one was detected");
                 }
 
                 return this.DeserializeWithIonConstructor(ionConstructors.First(), reader);


### PR DESCRIPTION
Resolves https://github.com/amzn/ion-object-mapper-dotnet/issues/12.

By default, C# objects are created using the `Activator.CreateInstance(Type)` method which calls the default constructor. If you want to supply a constructor yourself, you can markup a constructor with the `IonConstructor` Attribute. Additionally, the parameters to the constructor must be specified using the `IonPropertyName` Attribute again:

```c#
public class Wheel
{
    private string specification;
    
    [IonConstructor]
    public Wheel([IonPropertyName("specification")] string specification)
    {
         this.specification = specification;
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
