### PR TITLE
Implement AnnotatedIonSerializers

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonSerializerTest.cs
@@ -35,9 +35,9 @@ namespace Amazon.IonObjectMapper.Test
             Check(6.02214076e23d); // double
             Check(567.9876543m); // decimal
             Check(BigDecimal.Parse("2.71828"));
-            Check(DateTime.Parse("2009-10-10T13:15:21Z")); 
-            Check("Civic"); 
-            Check(new SymbolToken("my symbol", SymbolToken.UnknownSid)); 
+            Check(DateTime.Parse("2009-10-10T13:15:21Z"));
+            Check("Civic");
+            Check(new SymbolToken("my symbol", SymbolToken.UnknownSid));
             Check(Encoding.UTF8.GetBytes("This is an Ion blob")); // blob
             Check(MakeIonClob("This is an Ion clob"), "This is an Ion clob"); // clob
             Check(Guid.NewGuid()); // guid
@@ -59,8 +59,30 @@ namespace Amazon.IonObjectMapper.Test
                 { "two", 2 },
                 { "three", 3 }
             };
-            Assert.AreEqual(TestDictionary.PrettyString(dictionary), 
+            Assert.AreEqual(TestDictionary.PrettyString(dictionary),
                 TestDictionary.PrettyString(Serde<Dictionary<string, int>>(dictionary)));
+        }
+
+        [TestMethod]
+        public void AnnotatedIonSerializerSerialization()
+        {
+            var annotatedIonSerializer = new Dictionary<string, IIonSerializer>();
+            annotatedIonSerializer.Add("OEM.Manufacturer", new SupraManufacturerSerializer());
+
+            var customizedSerializer = new IonSerializer(new IonSerializationOptions { AnnotatedIonSerializers = annotatedIonSerializer });
+
+            Assert.AreEqual("BMW", Serde(customizedSerializer, TestObjects.a90).Brand);
+        }
+
+        [TestMethod]
+        public void AnnotatedIonSerializerDeserialization()
+        {
+            var annotatedIonDeserializer = new Dictionary<string, IIonSerializer>();
+            annotatedIonDeserializer.Add("OEM.Manufacturer", new SupraManufacturerDeserializer());
+
+            var customizedDeserializer = new IonSerializer(new IonSerializationOptions { AnnotatedIonSerializers = annotatedIonDeserializer });
+
+            Assert.AreEqual("BMW", Serde(customizedDeserializer, TestObjects.a90).Brand);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -78,6 +78,11 @@ namespace Amazon.IonObjectMapper.Test
             return "<Motorcycle>{ Brand: " + Brand + ", color: " + color + ", canOffroad: " + canOffroad + " }";
         }
     }
+    public class Supra : Vehicle
+    {
+        [IonAnnotateType(Name = "Manufacturer", Prefix = "OEM")]
+        public string Brand { get; set; } = "Toyota";
+    }
 
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Yacht : Boat
@@ -171,6 +176,8 @@ namespace Amazon.IonObjectMapper.Test
         };
 
         public static string JohnIonText = "{name:\"John\",id:13,course:null}";
+        
+        public static Supra a90 = new Supra();
 
         public static Truck nativeTruck = new Truck();
 

--- a/Amazon.IonObjectMapper.Test/TestSerializers.cs
+++ b/Amazon.IonObjectMapper.Test/TestSerializers.cs
@@ -174,4 +174,30 @@ namespace Amazon.IonObjectMapper.Test
             writer.WriteBlob(new byte[item.ToByteArray().Length]);
         }
     }
+
+    public class SupraManufacturerDeserializer : IonSerializer<string>
+    {
+        public override string Deserialize(IIonReader reader)
+        {
+            return "BMW";
+        }
+
+        public override void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString(item);
+        }
+    }
+
+    public class SupraManufacturerSerializer : IonSerializer<string>
+    {
+        public override string Deserialize(IIonReader reader)
+        {
+            return reader.StringValue();
+        }
+
+        public override void Serialize(IIonWriter writer, string item)
+        {
+            writer.WriteString("BMW");
+        }
+    }
 }

--- a/Amazon.IonObjectMapper/IonSerializationOptions.cs
+++ b/Amazon.IonObjectMapper/IonSerializationOptions.cs
@@ -128,5 +128,10 @@ namespace Amazon.IonObjectMapper
         /// to further customize behavior.
         /// </summary>
         public Dictionary<string, object> CustomContext { get; set; }
+
+        /// <summary>
+        /// Gets option to specify custom serializers for any given Ion type annotation.
+        /// </summary>
+        public Dictionary<string, IIonSerializer> AnnotatedIonSerializers { get; set; }
     }
 }

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -217,6 +217,12 @@ namespace Amazon.IonObjectMapper
                 }
 
                 writer.SetFieldName(ionPropertyName);
+                var ionAnnotateTypes = (IEnumerable<IonAnnotateTypeAttribute>)property.GetCustomAttributes(typeof(IonAnnotateTypeAttribute));
+                if (this.ionSerializer.TryAnnotatedIonSerializer(writer, propertyValue, ionAnnotateTypes))
+                {
+                    continue;
+                }
+
                 this.ionSerializer.Serialize(writer, propertyValue);
             }
 
@@ -247,6 +253,12 @@ namespace Amazon.IonObjectMapper
                 }
 
                 writer.SetFieldName(ionFieldName);
+                var ionAnnotateTypes = (IEnumerable<IonAnnotateTypeAttribute>)field.GetCustomAttributes(typeof(IonAnnotateTypeAttribute));
+                if (this.ionSerializer.TryAnnotatedIonSerializer(writer, fieldValue, ionAnnotateTypes))
+                {
+                    continue;
+                }
+
                 this.ionSerializer.Serialize(writer, fieldValue);
             }
 


### PR DESCRIPTION
Implement AnnotatedIonSerializers

This change allows the user to configure a IDictionary<string, IIonSerializer> where the string is an Ion Type annotation.

On Serialization, if the type of c# object being serialized has an IonAnnotateType attribute, it will apply the current AnnotationConvention rule to it, which gives a string. If this string matches the key in the dictionary, it will use the mapped IIonSerializer value to serialize the object.

On Deserialization, it will get the current TypeAnnotations from the Ion object as a string, and similarly use it to find the serializer to use for deserialization in the library.
