### PR TITLE
Clarify public properties are serialized/deserialized

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -153,7 +153,7 @@ public class Engine
 }
 ```
 
-the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all public gettable properties will be serialized and all public settable properties will be deserialized, but this can be configured as specified later in this document.
+the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable public properties will be serialized and all settable public properties will be deserialized, but this can be configured as specified later in this document.
 
 ### Default behavior when deserializing annotated Ion
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -153,7 +153,7 @@ public class Engine
 }
 ```
 
-the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document.
+the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all public gettable properties will be serialized and all public settable properties will be deserialized, but this can be configured as specified later in this document.
 
 ### Default behavior when deserializing annotated Ion
 
@@ -306,12 +306,12 @@ public class Car
 
 ### Fields
 
-By default, C#fields are ignored. However, they can be annotated with an `Attribute` to be included or by an option specified later. Even private fields may be specified.
+By default, C# fields are ignored. However, they can be annotated with an `IonField` attribute to be included or by an option specified later. Even private fields may be specified.
 
 ```c#
 public class Car
 {
-     [IonField]
+    [IonField]
     private string color;
 }
 ```
@@ -325,7 +325,8 @@ By default, C# objects are created using the `Activator.CreateInstance(Type)` me
 ```c#
 public class Wheel
 {
-     private string specification;
+    private string specification;
+
     [IonConstructor]
     public Wheel([IonPropertyName("specification")] string specification)
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Dotnet QLDB driver integration test was inserting a C# object using the object mapper serializer but it showed up as an empty struct in the database. After investigation, it was found that the object we were inserting had a property with default access modifier (internal) and it was not serialized into Ion binary. 

e.g.
```
  class ParameterObject
  {
      string Name //<- this was not being serialized.
      {
          get
          {
              return Constants.SingleDocumentValue;
          }
      }
```

This PR is to update the spec to mention that only public properties are serialized/deserialized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
