### PR TITLE
Allow serialization/deserialization of internal and protected internal properties.

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -621,7 +621,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingPropertiesWithOnlySetter()
+        public void SerializePropertiesWithOnlySetter()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(new ClassWithOnlySetProperty("test")));
 
@@ -629,7 +629,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingPropertiesWithAccessModifiers()
+        public void SerializePropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithProperties));
 
@@ -642,7 +642,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingReadOnlyPropertiesWithAccessModifiers()
+        public void SerializeReadOnlyPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithReadonlyProperties));
 
@@ -655,7 +655,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingIonPropertyNamesWithAccessModifiers()
+        public void SerializeIonPropertyNamesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithIonPropertyNameAttributes));
 
@@ -668,7 +668,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingMethodsWithAccessModifiers()
+        public void SerializeMethodsWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithMethods));
 
@@ -681,7 +681,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
+        public void SerializeAndDeserializePropertiesWithAccessModifiers()
         {
             Check("<ClassWithProperties>{ PublicProperty: Public Value, ProtectedProperty: , " +
                 "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
@@ -689,7 +689,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
+        public void SerializeAndDeserializeReadOnlyPropertiesWithAccessModifiers()
         {
             Check("<ClassWithReadonlyProperties>{ PublicProperty: Public Value, ProtectedProperty: , " +
                 "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
@@ -697,7 +697,7 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
+        public void SerializeAndDeserializeIonPropertyNamesWithAccessModifiers()
         {
             Check("<ClassWithIonPropertyNamesAttribute>{ PublicProperty: Public Value, ProtectedProperty: Protected Value, " +
                 "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
@@ -705,11 +705,19 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
-        public void TestSerializingAndDeserializingMethodsWithAccessModifiers()
+        public void SerializeAndDeserializeMethodsWithAccessModifiers()
         {
             Check("<ClassWithMethods>{ PublicValue: Public Value, ProtectedValue: Protected Value, " +
                 "ProtectedInternalValue: Protected Internal Value, InternalValue: Internal Value, " +
                 "PrivateValue: Private Value, PrivateProtectedValue: Private Protected Value }", TestObjects.objectWithMethods);
+        }
+
+        [TestMethod]
+        public void DeserializeToPrivateProperty()
+        {
+            var stream = defaultSerializer.Serialize(new ObjectWithPublicGetter { Property = "value" } );
+            var deserializedObject = defaultSerializer.Deserialize<ObjectWithPrivateSetter>(stream);
+            Assert.IsNull(deserializedObject.field);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -673,5 +673,23 @@ namespace Amazon.IonObjectMapper.Test
             Assert.AreEqual("", deserializedObject.GetPrivateProperty());
             Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
         }
+
+        [TestMethod]
+        public void TestSerializingAndDeserializingMethodsWithAccessModifiers()
+        {
+            var classWithMethods = new ClassWithMethods(publicValue: "PublicValue", defaultValue: "DefaultValue",
+                protectedValue: "ProtectedValue", protectedInternalValue: "ProtectedInternalValue", internalValue: "InternalValue",
+                privateValue: "PrivateValue", privateProtectedValue: "PrivateProtectedValue");
+
+            var deserializedObject = Serde(classWithMethods);
+
+            Assert.AreEqual("PublicValue", deserializedObject.publicValue);
+            Assert.IsNull(deserializedObject.defaultValue);
+            Assert.IsNull(deserializedObject.protectedValue);
+            Assert.AreEqual("ProtectedInternalValue", deserializedObject.protectedInternalValue);
+            Assert.AreEqual("InternalValue", deserializedObject.internalValue);
+            Assert.IsNull(deserializedObject.privateValue);
+            Assert.IsNull(deserializedObject.privateProtectedValue);
+        }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -717,7 +717,7 @@ namespace Amazon.IonObjectMapper.Test
         {
             var stream = defaultSerializer.Serialize(new ObjectWithPublicGetter { Property = "value" } );
             var deserializedObject = defaultSerializer.Deserialize<ObjectWithPrivateSetter>(stream);
-            Assert.IsNull(deserializedObject.field);
+            Assert.IsNull(deserializedObject.val);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -630,11 +630,11 @@ namespace Amazon.IonObjectMapper.Test
             var deserializedObject = Serde(objectWithProperties);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.IsNull(deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
-            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
-            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
 
         [TestMethod]
@@ -647,11 +647,11 @@ namespace Amazon.IonObjectMapper.Test
             var deserializedObject = Serde(objectWithReadonlyProperties);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.IsNull(deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
-            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
-            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
 
         [TestMethod]
@@ -664,11 +664,11 @@ namespace Amazon.IonObjectMapper.Test
             var deserializedObject = Serde(objectWithIonPropertyNames);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.IsNull(deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
-            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
-            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProperty());
+            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
 
         [TestMethod]

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -623,9 +623,9 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
         {
-            var objectWithProperties = new ClassWithProperties(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
-                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
-                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+            var objectWithProperties = new ClassWithProperties(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
+                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
+                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
 
             var deserializedObject = Serde(objectWithProperties);
 
@@ -640,9 +640,9 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
         {
-            var objectWithReadonlyProperties = new ClassWithReadonlyProperties(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
-                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
-                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+            var objectWithReadonlyProperties = new ClassWithReadonlyProperties(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
+                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
+                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
 
             var deserializedObject = Serde(objectWithReadonlyProperties);
 
@@ -657,9 +657,9 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
         {
-            var objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
-                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
-                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+            var objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
+                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
+                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
 
             var deserializedObject = Serde(objectWithIonPropertyNames);
 

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -621,18 +621,66 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
+        public void TestSerializingPropertiesWithAccessModifiers()
+        {
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithProperties));
+            Assert.AreEqual("Public Property", serialized.GetField("publicProperty").StringValue);
+            Assert.AreEqual("Protected Internal Property", serialized.GetField("protectedInternalProperty").StringValue);
+            Assert.AreEqual("Internal Property", serialized.GetField("internalProperty").StringValue);
+
+            Assert.IsFalse(serialized.ContainsField("protectedProperty"));
+            Assert.IsFalse(serialized.ContainsField("privateProperty"));
+            Assert.IsFalse(serialized.ContainsField("protectedPrivateProperty"));
+        }
+
+        [TestMethod]
+        public void TestSerializingReadOnlyPropertiesWithAccessModifiers()
+        {
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithReadonlyProperties));
+            Assert.AreEqual("Public Property", serialized.GetField("<PublicProperty>k__BackingField").StringValue);
+            Assert.AreEqual("Protected Internal Property", serialized.GetField("<ProtectedInternalProperty>k__BackingField").StringValue);
+            Assert.AreEqual("Internal Property", serialized.GetField("<InternalProperty>k__BackingField").StringValue);
+
+            Assert.IsFalse(serialized.ContainsField("<ProtectedProperty>k__BackingField"));
+            Assert.IsFalse(serialized.ContainsField("<PrivateProperty>k__BackingField"));
+            Assert.IsFalse(serialized.ContainsField("<ProtectedPrivateProperty>k__BackingField"));
+        }
+
+        [TestMethod]
+        public void TestSerializingIonPropertyNamesWithAccessModifiers()
+        {
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithIonPropertyNames));
+            Assert.AreEqual("Public Property", serialized.GetField("Public Property").StringValue);
+            Assert.AreEqual("Protected Internal Property", serialized.GetField("Protected Internal Property").StringValue);
+            Assert.AreEqual("Internal Property", serialized.GetField("Internal Property").StringValue);
+
+            Assert.IsFalse(serialized.ContainsField("Protected Property"));
+            Assert.IsFalse(serialized.ContainsField("Private Property"));
+            Assert.IsFalse(serialized.ContainsField("Protected Private Property"));
+        }
+
+        [TestMethod]
+        public void TestSerializingMethodsWithAccessModifiers()
+        {
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithmethods));
+
+            Assert.AreEqual("Public Value", serialized.GetField("public value").StringValue);
+            Assert.AreEqual("Protected Value", serialized.GetField("protected value").StringValue);
+            Assert.AreEqual("Protected Internal Value", serialized.GetField("protected internal value").StringValue);
+            Assert.AreEqual("Internal Value", serialized.GetField("internal value").StringValue);
+            Assert.AreEqual("Private Value", serialized.GetField("private value").StringValue);
+            Assert.AreEqual("Private Protected Value", serialized.GetField("private protected value").StringValue);
+        }
+
+        [TestMethod]
         public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
         {
-            var objectWithProperties = new ClassWithProperties(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
-                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
-                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
+            var deserializedObject = Serde(TestObjects.objectWithProperties);
 
-            var deserializedObject = Serde(objectWithProperties);
-
-            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
@@ -640,16 +688,12 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
         {
-            var objectWithReadonlyProperties = new ClassWithReadonlyProperties(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
-                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
-                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
+            var deserializedObject = Serde(TestObjects.objectWithReadonlyProperties);
 
-            var deserializedObject = Serde(objectWithReadonlyProperties);
-
-            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
@@ -657,16 +701,12 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
         {
-            var objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(publicProperty: "PublicProperty", protectedProperty: "ProtectedProperty",
-                protectedInternalProperty: "ProtectedInternalProperty", internalProperty: "InternalProperty",
-                privateProperty: "PrivateProperty", privateProtectedProperty: "PrivateProtectedProperty");
+            var deserializedObject = Serde(TestObjects.objectWithIonPropertyNames);
 
-            var deserializedObject = Serde(objectWithIonPropertyNames);
-
-            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
@@ -674,18 +714,14 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingMethodsWithAccessModifiers()
         {
-            var objectWithMethods = new ClassWithMethods(publicValue: "PublicValue", protectedValue: "ProtectedValue",
-                protectedInternalValue: "ProtectedInternalValue", internalValue: "InternalValue",
-                privateValue: "PrivateValue", privateProtectedValue: "PrivateProtectedValue");
+            var deserializedObject = Serde(TestObjects.objectWithmethods);
 
-            var deserializedObject = Serde(objectWithMethods);
-
-            Assert.AreEqual("PublicValue", deserializedObject.publicValue);
-            Assert.AreEqual("ProtectedValue", deserializedObject.protectedValue);
-            Assert.AreEqual("ProtectedInternalValue", deserializedObject.protectedInternalValue);
-            Assert.AreEqual("InternalValue", deserializedObject.internalValue);
-            Assert.AreEqual("PrivateValue", deserializedObject.privateValue);
-            Assert.AreEqual("PrivateProtectedValue", deserializedObject.privateProtectedValue);
+            Assert.AreEqual("Public Value", deserializedObject.publicValue);
+            Assert.AreEqual("Protected Value", deserializedObject.protectedValue);
+            Assert.AreEqual("Protected Internal Value", deserializedObject.protectedInternalValue);
+            Assert.AreEqual("Internal Value", deserializedObject.internalValue);
+            Assert.AreEqual("Private Value", deserializedObject.privateValue);
+            Assert.AreEqual("Private Protected Value", deserializedObject.privateProtectedValue);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -621,6 +621,14 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
+        public void TestSerializingPropertiesWithOnlySetter()
+        {
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(new ClassWithOnlySetProperty("test")));
+
+            Assert.IsFalse(serialized.ContainsField("setOnlyProperty"));
+        }
+
+        [TestMethod]
         public void TestSerializingPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithProperties));

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -662,9 +662,9 @@ namespace Amazon.IonObjectMapper.Test
             Assert.AreEqual("Public Value", serialized.GetField("Public Property").StringValue);
             Assert.AreEqual("Protected Internal Value", serialized.GetField("Protected Internal Property").StringValue);
             Assert.AreEqual("Internal Value", serialized.GetField("Internal Property").StringValue);
-            Assert.IsFalse(serialized.ContainsField("Protected Property"));
-            Assert.IsFalse(serialized.ContainsField("Private Property"));
-            Assert.IsFalse(serialized.ContainsField("Protected Private Property"));
+            Assert.AreEqual("Protected Value", serialized.GetField("Protected Property").StringValue);
+            Assert.AreEqual("Private Value", serialized.GetField("Private Property").StringValue);
+            Assert.AreEqual("Private Protected Value", serialized.GetField("Private Protected Property").StringValue);
         }
 
         [TestMethod]
@@ -699,9 +699,9 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
         {
-            Check("<ClassWithIonPropertyNamesAttribute>{ PublicProperty: Public Value, ProtectedProperty: , " +
+            Check("<ClassWithIonPropertyNamesAttribute>{ PublicProperty: Public Value, ProtectedProperty: Protected Value, " +
                 "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
-                "PrivateProperty: , PrivateProtectedProperty:  }", TestObjects.objectWithIonPropertyNameAttributes);
+                "PrivateProperty: Private Value, PrivateProtectedProperty: Private Protected Value }", TestObjects.objectWithIonPropertyNameAttributes);
         }
 
         [TestMethod]

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -623,14 +623,13 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
         {
-            var classWithProperties = new ClassWithProperties(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
-                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+            var objectWithProperties = new ClassWithProperties(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
+                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
                 PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
 
-            var deserializedObject = Serde(classWithProperties);
+            var deserializedObject = Serde(objectWithProperties);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
             Assert.AreEqual("", deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
@@ -641,14 +640,13 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
         {
-            var classWithReadonlyProperties = new ClassWithReadonlyProperties(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
-                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+            var objectWithReadonlyProperties = new ClassWithReadonlyProperties(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
+                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
                 PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
 
-            var deserializedObject = Serde(classWithReadonlyProperties);
+            var deserializedObject = Serde(objectWithReadonlyProperties);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
             Assert.AreEqual("", deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
@@ -659,14 +657,13 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
         {
-            var classWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
-                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+            var objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(PublicProperty: "PublicProperty", ProtectedProperty: "ProtectedProperty",
+                ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
                 PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
 
-            var deserializedObject = Serde(classWithIonPropertyNames);
+            var deserializedObject = Serde(objectWithIonPropertyNames);
 
             Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
-            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
             Assert.AreEqual("", deserializedObject.GetProtectedProperty());
             Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
             Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
@@ -677,14 +674,13 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingMethodsWithAccessModifiers()
         {
-            var classWithMethods = new ClassWithMethods(publicValue: "PublicValue", defaultValue: "DefaultValue",
-                protectedValue: "ProtectedValue", protectedInternalValue: "ProtectedInternalValue", internalValue: "InternalValue",
+            var objectWithMethods = new ClassWithMethods(publicValue: "PublicValue", protectedValue: "ProtectedValue",
+                protectedInternalValue: "ProtectedInternalValue", internalValue: "InternalValue",
                 privateValue: "PrivateValue", privateProtectedValue: "PrivateProtectedValue");
 
-            var deserializedObject = Serde(classWithMethods);
+            var deserializedObject = Serde(objectWithMethods);
 
             Assert.AreEqual("PublicValue", deserializedObject.publicValue);
-            Assert.AreEqual("DefaultValue", deserializedObject.defaultValue);
             Assert.AreEqual("ProtectedValue", deserializedObject.protectedValue);
             Assert.AreEqual("ProtectedInternalValue", deserializedObject.protectedInternalValue);
             Assert.AreEqual("InternalValue", deserializedObject.internalValue);

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -619,5 +619,59 @@ namespace Amazon.IonObjectMapper.Test
         {
             Assert.AreEqual(actual.ToString(), TestObjects.nativeTruck.ToString());
         }
+
+        [TestMethod]
+        public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
+        {
+            var classWithProperties = new ClassWithProperties(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
+                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+
+            var deserializedObject = Serde(classWithProperties);
+
+            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
+            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
+            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+        }
+
+        [TestMethod]
+        public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
+        {
+            var classWithReadonlyProperties = new ClassWithReadonlyProperties(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
+                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+
+            var deserializedObject = Serde(classWithReadonlyProperties);
+
+            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
+            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
+            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+        }
+
+        [TestMethod]
+        public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
+        {
+            var classWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute(PublicProperty: "PublicProperty", DefaultProperty: "DefaultProperty",
+                ProtectedProperty: "ProtectedProperty", ProtectedInternalProperty: "ProtectedInternalProperty", InternalProperty: "InternalProperty",
+                PrivateProperty: "PrivateProperty", PrivateProtectedProperty: "PrivateProtectedProperty");
+
+            var deserializedObject = Serde(classWithIonPropertyNames);
+
+            Assert.AreEqual("PublicProperty", deserializedObject.PublicProperty);
+            Assert.AreEqual("", deserializedObject.GetDefaultProperty());
+            Assert.AreEqual("", deserializedObject.GetProtectedProperty());
+            Assert.AreEqual("ProtectedInternalProperty", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("InternalProperty", deserializedObject.InternalProperty);
+            Assert.AreEqual("", deserializedObject.GetPrivateProperty());
+            Assert.AreEqual("", deserializedObject.GetPrivateProtectedProperty());
+        }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -624,9 +624,9 @@ namespace Amazon.IonObjectMapper.Test
         public void TestSerializingPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithProperties));
-            Assert.AreEqual("Public Property", serialized.GetField("publicProperty").StringValue);
-            Assert.AreEqual("Protected Internal Property", serialized.GetField("protectedInternalProperty").StringValue);
-            Assert.AreEqual("Internal Property", serialized.GetField("internalProperty").StringValue);
+            Assert.AreEqual("Public Value", serialized.GetField("publicProperty").StringValue);
+            Assert.AreEqual("Protected Internal Value", serialized.GetField("protectedInternalProperty").StringValue);
+            Assert.AreEqual("Internal Value", serialized.GetField("internalProperty").StringValue);
 
             Assert.IsFalse(serialized.ContainsField("protectedProperty"));
             Assert.IsFalse(serialized.ContainsField("privateProperty"));
@@ -637,9 +637,9 @@ namespace Amazon.IonObjectMapper.Test
         public void TestSerializingReadOnlyPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithReadonlyProperties));
-            Assert.AreEqual("Public Property", serialized.GetField("<PublicProperty>k__BackingField").StringValue);
-            Assert.AreEqual("Protected Internal Property", serialized.GetField("<ProtectedInternalProperty>k__BackingField").StringValue);
-            Assert.AreEqual("Internal Property", serialized.GetField("<InternalProperty>k__BackingField").StringValue);
+            Assert.AreEqual("Public Value", serialized.GetField("<PublicProperty>k__BackingField").StringValue);
+            Assert.AreEqual("Protected Internal Value", serialized.GetField("<ProtectedInternalProperty>k__BackingField").StringValue);
+            Assert.AreEqual("Internal Value", serialized.GetField("<InternalProperty>k__BackingField").StringValue);
 
             Assert.IsFalse(serialized.ContainsField("<ProtectedProperty>k__BackingField"));
             Assert.IsFalse(serialized.ContainsField("<PrivateProperty>k__BackingField"));
@@ -650,9 +650,9 @@ namespace Amazon.IonObjectMapper.Test
         public void TestSerializingIonPropertyNamesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithIonPropertyNames));
-            Assert.AreEqual("Public Property", serialized.GetField("Public Property").StringValue);
-            Assert.AreEqual("Protected Internal Property", serialized.GetField("Protected Internal Property").StringValue);
-            Assert.AreEqual("Internal Property", serialized.GetField("Internal Property").StringValue);
+            Assert.AreEqual("Public Value", serialized.GetField("Public Property").StringValue);
+            Assert.AreEqual("Protected Internal Value", serialized.GetField("Protected Internal Property").StringValue);
+            Assert.AreEqual("Internal Value", serialized.GetField("Internal Property").StringValue);
 
             Assert.IsFalse(serialized.ContainsField("Protected Property"));
             Assert.IsFalse(serialized.ContainsField("Private Property"));
@@ -677,10 +677,10 @@ namespace Amazon.IonObjectMapper.Test
         {
             var deserializedObject = Serde(TestObjects.objectWithProperties);
 
-            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
@@ -690,10 +690,10 @@ namespace Amazon.IonObjectMapper.Test
         {
             var deserializedObject = Serde(TestObjects.objectWithReadonlyProperties);
 
-            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }
@@ -703,10 +703,10 @@ namespace Amazon.IonObjectMapper.Test
         {
             var deserializedObject = Serde(TestObjects.objectWithIonPropertyNames);
 
-            Assert.AreEqual("Public Property", deserializedObject.PublicProperty);
+            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
             Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Property", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Property", deserializedObject.InternalProperty);
+            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
+            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
             Assert.IsNull(deserializedObject.GetPrivateProperty());
             Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
         }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -632,10 +632,10 @@ namespace Amazon.IonObjectMapper.Test
         public void TestSerializingPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithProperties));
+
             Assert.AreEqual("Public Value", serialized.GetField("publicProperty").StringValue);
             Assert.AreEqual("Protected Internal Value", serialized.GetField("protectedInternalProperty").StringValue);
             Assert.AreEqual("Internal Value", serialized.GetField("internalProperty").StringValue);
-
             Assert.IsFalse(serialized.ContainsField("protectedProperty"));
             Assert.IsFalse(serialized.ContainsField("privateProperty"));
             Assert.IsFalse(serialized.ContainsField("protectedPrivateProperty"));
@@ -645,10 +645,10 @@ namespace Amazon.IonObjectMapper.Test
         public void TestSerializingReadOnlyPropertiesWithAccessModifiers()
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithReadonlyProperties));
+
             Assert.AreEqual("Public Value", serialized.GetField("<PublicProperty>k__BackingField").StringValue);
             Assert.AreEqual("Protected Internal Value", serialized.GetField("<ProtectedInternalProperty>k__BackingField").StringValue);
             Assert.AreEqual("Internal Value", serialized.GetField("<InternalProperty>k__BackingField").StringValue);
-
             Assert.IsFalse(serialized.ContainsField("<ProtectedProperty>k__BackingField"));
             Assert.IsFalse(serialized.ContainsField("<PrivateProperty>k__BackingField"));
             Assert.IsFalse(serialized.ContainsField("<ProtectedPrivateProperty>k__BackingField"));
@@ -657,11 +657,11 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingIonPropertyNamesWithAccessModifiers()
         {
-            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithIonPropertyNames));
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithIonPropertyNameAttributes));
+
             Assert.AreEqual("Public Value", serialized.GetField("Public Property").StringValue);
             Assert.AreEqual("Protected Internal Value", serialized.GetField("Protected Internal Property").StringValue);
             Assert.AreEqual("Internal Value", serialized.GetField("Internal Property").StringValue);
-
             Assert.IsFalse(serialized.ContainsField("Protected Property"));
             Assert.IsFalse(serialized.ContainsField("Private Property"));
             Assert.IsFalse(serialized.ContainsField("Protected Private Property"));
@@ -670,7 +670,7 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingMethodsWithAccessModifiers()
         {
-            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithmethods));
+            IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithMethods));
 
             Assert.AreEqual("Public Value", serialized.GetField("public value").StringValue);
             Assert.AreEqual("Protected Value", serialized.GetField("protected value").StringValue);
@@ -683,53 +683,33 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void TestSerializingAndDeserializingPropertiesWithAccessModifiers()
         {
-            var deserializedObject = Serde(TestObjects.objectWithProperties);
-
-            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
-            Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
-            Assert.IsNull(deserializedObject.GetPrivateProperty());
-            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
+            Check("<ClassWithProperties>{ PublicProperty: Public Value, ProtectedProperty: , " +
+                "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
+                "PrivateProperty: , PrivateProtectedProperty:  }", TestObjects.objectWithProperties);
         }
 
         [TestMethod]
         public void TestSerializingAndDeserializingReadOnlyPropertiesWithAccessModifiers()
         {
-            var deserializedObject = Serde(TestObjects.objectWithReadonlyProperties);
-
-            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
-            Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
-            Assert.IsNull(deserializedObject.GetPrivateProperty());
-            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
+            Check("<ClassWithReadonlyProperties>{ PublicProperty: Public Value, ProtectedProperty: , " +
+                "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
+                "PrivateProperty: , PrivateProtectedProperty:  }", TestObjects.objectWithReadonlyProperties);
         }
 
         [TestMethod]
         public void TestSerializingAndDeserializingIonPropertyNamesWithAccessModifiers()
         {
-            var deserializedObject = Serde(TestObjects.objectWithIonPropertyNames);
-
-            Assert.AreEqual("Public Value", deserializedObject.PublicProperty);
-            Assert.IsNull(deserializedObject.GetProtectedProperty());
-            Assert.AreEqual("Protected Internal Value", deserializedObject.ProtectedInternalProperty);
-            Assert.AreEqual("Internal Value", deserializedObject.InternalProperty);
-            Assert.IsNull(deserializedObject.GetPrivateProperty());
-            Assert.IsNull(deserializedObject.GetPrivateProtectedProperty());
+            Check("<ClassWithIonPropertyNamesAttribute>{ PublicProperty: Public Value, ProtectedProperty: , " +
+                "ProtectedInternalProperty: Protected Internal Value, InternalProperty: Internal Value, " +
+                "PrivateProperty: , PrivateProtectedProperty:  }", TestObjects.objectWithIonPropertyNameAttributes);
         }
 
         [TestMethod]
         public void TestSerializingAndDeserializingMethodsWithAccessModifiers()
         {
-            var deserializedObject = Serde(TestObjects.objectWithmethods);
-
-            Assert.AreEqual("Public Value", deserializedObject.publicValue);
-            Assert.AreEqual("Protected Value", deserializedObject.protectedValue);
-            Assert.AreEqual("Protected Internal Value", deserializedObject.protectedInternalValue);
-            Assert.AreEqual("Internal Value", deserializedObject.internalValue);
-            Assert.AreEqual("Private Value", deserializedObject.privateValue);
-            Assert.AreEqual("Private Protected Value", deserializedObject.privateProtectedValue);
+            Check("<ClassWithMethods>{ PublicValue: Public Value, ProtectedValue: Protected Value, " +
+                "ProtectedInternalValue: Protected Internal Value, InternalValue: Internal Value, " +
+                "PrivateValue: Private Value, PrivateProtectedValue: Private Protected Value }", TestObjects.objectWithMethods);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -684,12 +684,12 @@ namespace Amazon.IonObjectMapper.Test
             var deserializedObject = Serde(classWithMethods);
 
             Assert.AreEqual("PublicValue", deserializedObject.publicValue);
-            Assert.IsNull(deserializedObject.defaultValue);
-            Assert.IsNull(deserializedObject.protectedValue);
+            Assert.AreEqual("DefaultValue", deserializedObject.defaultValue);
+            Assert.AreEqual("ProtectedValue", deserializedObject.protectedValue);
             Assert.AreEqual("ProtectedInternalValue", deserializedObject.protectedInternalValue);
             Assert.AreEqual("InternalValue", deserializedObject.internalValue);
-            Assert.IsNull(deserializedObject.privateValue);
-            Assert.IsNull(deserializedObject.privateProtectedValue);
+            Assert.AreEqual("PrivateValue", deserializedObject.privateValue);
+            Assert.AreEqual("PrivateProtectedValue", deserializedObject.privateProtectedValue);
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -721,4 +721,113 @@ namespace Amazon.IonObjectMapper.Test
             return $"{DefaultProperty}";
         }
     }
+
+    public class ClassWithMethods
+    {
+        public string publicValue;
+        public string defaultValue;
+        public string protectedValue;
+        public string protectedInternalValue;
+        public string internalValue;
+        public string privateValue;
+        public string privateProtectedValue;
+
+        public ClassWithMethods() { }
+
+        public ClassWithMethods(string publicValue, string defaultValue, string protectedValue, string protectedInternalValue,
+            string internalValue, string privateValue, string privateProtectedValue)
+        {
+            this.publicValue = publicValue;
+            this.defaultValue = defaultValue;
+            this.protectedValue = protectedValue;
+            this.protectedInternalValue = protectedInternalValue;
+            this.internalValue = internalValue;
+            this.privateValue = privateValue;
+            this.privateProtectedValue = privateProtectedValue;
+        }
+
+        [IonPropertyGetter("public value")]
+        public string GetPublicValue()
+        {
+            return this.publicValue;
+        }
+
+        [IonPropertySetter("public value")]
+        public void SetPublicValue(string value)
+        {
+            this.publicValue = value;
+        }
+
+        [IonPropertyGetter("default value")]
+        string GetDefaultValue()
+        {
+            return this.defaultValue;
+        }
+
+        [IonPropertySetter("default value")]
+        void SetDefaultValue(string value)
+        {
+            this.defaultValue = value;
+        }
+
+        [IonPropertyGetter("protected value")]
+        protected string GetProtectedValue()
+        { 
+            return this.protectedValue;
+        }
+
+        [IonPropertySetter("protected value")]
+        protected void SetProtectedValue(string value)
+        {
+            this.protectedValue = value;
+        }
+
+        [IonPropertyGetter("protected internal value")]
+        protected internal string GetProtectedInternalValue()
+        {
+            return this.protectedInternalValue;
+        }
+
+        [IonPropertySetter("protected internal value")]
+        protected internal void SetProtectedInternalValue(string value)
+        {
+            this.protectedInternalValue = value;
+        }
+
+        [IonPropertyGetter("internal value")]
+        internal string GetInternalValue()
+        {
+            return this.internalValue;
+        }
+
+        [IonPropertySetter("internal value")]
+        internal void SetInternalValue(string value)
+        {
+            this.internalValue = value;
+        }
+
+        [IonPropertyGetter("private value")]
+        private string GetPrivateValue()
+        {
+            return this.privateValue;
+        }
+
+        [IonPropertySetter("private value")]
+        private void SetPrivateValue(string value)
+        {
+            this.privateValue = value;
+        }
+
+        [IonPropertyGetter("private protected value")]
+        private protected string GetPrivateProtectedValue()
+        {
+            return this.privateProtectedValue;
+        }
+
+        [IonPropertySetter("private protected value")]
+        private protected void SetPrivateProtectedValue(string value)
+        {
+            this.privateProtectedValue = value;
+        }
+    }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -508,17 +508,17 @@ namespace Amazon.IonObjectMapper.Test
 
         public string GetPrivateProtectedProperty()
         {
-            return $"{PrivateProtectedProperty}";
+            return PrivateProtectedProperty;
         }
 
         public string GetPrivateProperty()
         {
-            return $"{PrivateProperty}";
+            return PrivateProperty;
         }
 
         public string GetProtectedProperty()
         {
-            return $"{ProtectedProperty}";
+            return ProtectedProperty;
         }
     }
 
@@ -546,17 +546,17 @@ namespace Amazon.IonObjectMapper.Test
 
         public string GetPrivateProtectedProperty()
         {
-            return $"{PrivateProtectedProperty}";
+            return PrivateProtectedProperty;
         }
 
         public string GetPrivateProperty()
         {
-            return $"{PrivateProperty}";
+            return PrivateProperty;
         }
 
         public string GetProtectedProperty()
         {
-            return $"{ProtectedProperty}";
+            return ProtectedProperty;
         }
     }
 
@@ -596,17 +596,17 @@ namespace Amazon.IonObjectMapper.Test
 
         public string GetPrivateProtectedProperty()
         {
-            return $"{PrivateProtectedProperty}";
+            return PrivateProtectedProperty;
         }
 
         public string GetPrivateProperty()
         {
-            return $"{PrivateProperty}";
+            return PrivateProperty;
         }
 
         public string GetProtectedProperty()
         {
-            return $"{ProtectedProperty}";
+            return ProtectedProperty;
         }
     }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -488,11 +488,10 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithProperties() { }
 
-        public ClassWithProperties(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+        public ClassWithProperties(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
             string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
         {
             this.PublicProperty = PublicProperty;
-            this.DefaultProperty = DefaultProperty;
             this.ProtectedProperty = ProtectedProperty;
             this.ProtectedInternalProperty = ProtectedInternalProperty;
             this.InternalProperty = InternalProperty;
@@ -500,47 +499,12 @@ namespace Amazon.IonObjectMapper.Test
             this.PrivateProtectedProperty = PrivateProtectedProperty;
         }
 
-        public string PublicProperty
-        {
-            get;
-            set;
-        }
-
-        string DefaultProperty
-        {
-            get;
-            set;
-        }
-
-        protected string ProtectedProperty
-        {
-            get;
-            set;
-        }
-
-        protected internal string ProtectedInternalProperty
-        {
-            get;
-            set;
-        }
-
-        internal string InternalProperty
-        {
-            get;
-            set;
-        }
-
-        private string PrivateProperty
-        {
-            get;
-            set;
-        }
-
-        private protected string PrivateProtectedProperty
-        {
-            get;
-            set;
-        }
+        public string PublicProperty { get; set; }
+        protected string ProtectedProperty { get; set; }
+        protected internal string ProtectedInternalProperty { get; set; }
+        internal string InternalProperty { get; set; }
+        private string PrivateProperty { get; set; }
+        private protected string PrivateProtectedProperty { get; set; }
 
         public string GetPrivateProtectedProperty()
         {
@@ -555,11 +519,6 @@ namespace Amazon.IonObjectMapper.Test
         public string GetProtectedProperty()
         {
             return $"{ProtectedProperty}";
-        }
-
-        public string GetDefaultProperty()
-        {
-            return $"{DefaultProperty}";
         }
     }
 
@@ -567,11 +526,10 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithReadonlyProperties() { }
 
-        public ClassWithReadonlyProperties(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+        public ClassWithReadonlyProperties(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
             string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
         {
             this.PublicProperty = PublicProperty;
-            this.DefaultProperty = DefaultProperty;
             this.ProtectedProperty = ProtectedProperty;
             this.ProtectedInternalProperty = ProtectedInternalProperty;
             this.InternalProperty = InternalProperty;
@@ -579,40 +537,12 @@ namespace Amazon.IonObjectMapper.Test
             this.PrivateProtectedProperty = PrivateProtectedProperty;
         }
 
-        public string PublicProperty
-        {
-            get;
-        }
-
-        string DefaultProperty
-        {
-            get;
-        }
-
-        protected string ProtectedProperty
-        {
-            get;
-        }
-
-        protected internal string ProtectedInternalProperty
-        {
-            get;
-        }
-
-        internal string InternalProperty
-        {
-            get;
-        }
-
-        private string PrivateProperty
-        {
-            get;
-        }
-
-        private protected string PrivateProtectedProperty
-        {
-            get;
-        }
+        public string PublicProperty { get; }
+        protected string ProtectedProperty { get; }
+        protected internal string ProtectedInternalProperty { get; }
+        internal string InternalProperty { get; }
+        private string PrivateProperty { get; }
+        private protected string PrivateProtectedProperty { get; }
 
         public string GetPrivateProtectedProperty()
         {
@@ -627,11 +557,6 @@ namespace Amazon.IonObjectMapper.Test
         public string GetProtectedProperty()
         {
             return $"{ProtectedProperty}";
-        }
-
-        public string GetDefaultProperty()
-        {
-            return $"{DefaultProperty}";
         }
     }
 
@@ -640,11 +565,10 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithIonPropertyNamesAttribute() { }
 
-        public ClassWithIonPropertyNamesAttribute(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+        public ClassWithIonPropertyNamesAttribute(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
             string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
         {
             this.PublicProperty = PublicProperty;
-            this.DefaultProperty = DefaultProperty;
             this.ProtectedProperty = ProtectedProperty;
             this.ProtectedInternalProperty = ProtectedInternalProperty;
             this.InternalProperty = InternalProperty;
@@ -652,54 +576,23 @@ namespace Amazon.IonObjectMapper.Test
             this.PrivateProtectedProperty = PrivateProtectedProperty;
         }
 
-        [IonPropertyName("PublicPropertyz")]
-        public string PublicProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Public Property")]
+        public string PublicProperty { get; set; }
 
-        [IonPropertyName("DefaultPropertyz")]
-        string DefaultProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Protected Property")]
+        protected string ProtectedProperty { get; set; }
 
-        [IonPropertyName("ProtectedPropertyz")]
-        protected string ProtectedProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Protected Internal Property")]
+        protected internal string ProtectedInternalProperty { get; set; }
 
-        [IonPropertyName("ProtectedInternalPropertyz")]
-        protected internal string ProtectedInternalProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Internal Property")]
+        internal string InternalProperty { get; set; }
 
-        [IonPropertyName("InternalPropertyz")]
-        internal string InternalProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Private Property")]
+        private string PrivateProperty { get; set; }
 
-        [IonPropertyName("PrivatePropertyz")]
-        private string PrivateProperty
-        {
-            get;
-            set;
-        }
-
-        [IonPropertyName("PrivateProtectedPropertyz")]
-        private protected string PrivateProtectedProperty
-        {
-            get;
-            set;
-        }
+        [IonPropertyName("Private Protected Property")]
+        private protected string PrivateProtectedProperty { get; set; }
 
         public string GetPrivateProtectedProperty()
         {
@@ -715,17 +608,11 @@ namespace Amazon.IonObjectMapper.Test
         {
             return $"{ProtectedProperty}";
         }
-
-        public string GetDefaultProperty()
-        {
-            return $"{DefaultProperty}";
-        }
     }
 
     public class ClassWithMethods
     {
         public string publicValue;
-        public string defaultValue;
         public string protectedValue;
         public string protectedInternalValue;
         public string internalValue;
@@ -734,11 +621,10 @@ namespace Amazon.IonObjectMapper.Test
 
         public ClassWithMethods() { }
 
-        public ClassWithMethods(string publicValue, string defaultValue, string protectedValue, string protectedInternalValue,
+        public ClassWithMethods(string publicValue, string protectedValue, string protectedInternalValue,
             string internalValue, string privateValue, string privateProtectedValue)
         {
             this.publicValue = publicValue;
-            this.defaultValue = defaultValue;
             this.protectedValue = protectedValue;
             this.protectedInternalValue = protectedInternalValue;
             this.internalValue = internalValue;
@@ -756,18 +642,6 @@ namespace Amazon.IonObjectMapper.Test
         public void SetPublicValue(string value)
         {
             this.publicValue = value;
-        }
-
-        [IonPropertyGetter("default value")]
-        string GetDefaultValue()
-        {
-            return this.defaultValue;
-        }
-
-        [IonPropertySetter("default value")]
-        void SetDefaultValue(string value)
-        {
-            this.defaultValue = value;
         }
 
         [IonPropertyGetter("protected value")]

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -191,14 +191,14 @@ namespace Amazon.IonObjectMapper.Test
             Capacity = 2230,
         };
          
-        public static ClassWithProperties objectWithProperties = new ClassWithProperties("Public Property", "Protected Property",
-            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+        public static ClassWithProperties objectWithProperties = new ClassWithProperties("Public Value", "Protected Value",
+            "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
 
-        public static ClassWithReadonlyProperties objectWithReadonlyProperties = new ClassWithReadonlyProperties("Public Property", "Protected Property",
-            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+        public static ClassWithReadonlyProperties objectWithReadonlyProperties = new ClassWithReadonlyProperties("Public Value", "Protected Value",
+            "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
 
-        public static ClassWithIonPropertyNamesAttribute objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute("Public Property", "Protected Property",
-            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+        public static ClassWithIonPropertyNamesAttribute objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute("Public Value", "Protected Value",
+            "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
 
         public static ClassWithMethods objectWithmethods = new ClassWithMethods("Public Value", "Protected Value",
             "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
@@ -500,15 +500,15 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithProperties() { }
 
-        public ClassWithProperties(string publicProperty, string protectedProperty, string protectedInternalProperty,
-            string internalProperty, string privateProperty, string privateProtectedProperty)
+        public ClassWithProperties(string publicValue, string protectedValue, string protectedInternalValue,
+            string internalValue, string privateValue, string privateProtectedValue)
         {
-            this.PublicProperty = publicProperty;
-            this.ProtectedProperty = protectedProperty;
-            this.ProtectedInternalProperty = protectedInternalProperty;
-            this.InternalProperty = internalProperty;
-            this.PrivateProperty = privateProperty;
-            this.PrivateProtectedProperty = privateProtectedProperty;
+            this.PublicProperty = publicValue;
+            this.ProtectedProperty = protectedValue;
+            this.ProtectedInternalProperty = protectedInternalValue;
+            this.InternalProperty = internalValue;
+            this.PrivateProperty = privateValue;
+            this.PrivateProtectedProperty = privateProtectedValue;
         }
 
         public string PublicProperty { get; set; }
@@ -538,15 +538,15 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithReadonlyProperties() { }
 
-        public ClassWithReadonlyProperties(string publicProperty, string protectedProperty, string protectedInternalProperty,
-            string internalProperty, string privateProperty, string privateProtectedProperty)
+        public ClassWithReadonlyProperties(string publicValue, string protectedValue, string protectedInternalValue,
+            string internalValue, string privateValue, string privateProtectedValue)
         {
-            this.PublicProperty = publicProperty;
-            this.ProtectedProperty = protectedProperty;
-            this.ProtectedInternalProperty = protectedInternalProperty;
-            this.InternalProperty = internalProperty;
-            this.PrivateProperty = privateProperty;
-            this.PrivateProtectedProperty = privateProtectedProperty;
+            this.PublicProperty = publicValue;
+            this.ProtectedProperty = protectedValue;
+            this.ProtectedInternalProperty = protectedInternalValue;
+            this.InternalProperty = internalValue;
+            this.PrivateProperty = privateValue;
+            this.PrivateProtectedProperty = privateProtectedValue;
         }
 
         public string PublicProperty { get; }
@@ -577,15 +577,15 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithIonPropertyNamesAttribute() { }
 
-        public ClassWithIonPropertyNamesAttribute(string publicProperty, string protectedProperty, string protectedInternalProperty,
-            string internalProperty, string privateProperty, string privateProtectedProperty)
+        public ClassWithIonPropertyNamesAttribute(string publicValue, string protectedValue, string protectedInternalValue,
+            string internalValue, string privateValue, string privateProtectedValue)
         {
-            this.PublicProperty = publicProperty;
-            this.ProtectedProperty = protectedProperty;
-            this.ProtectedInternalProperty = protectedInternalProperty;
-            this.InternalProperty = internalProperty;
-            this.PrivateProperty = privateProperty;
-            this.PrivateProtectedProperty = PrivateProtectedProperty;
+            this.PublicProperty = publicValue;
+            this.ProtectedProperty = protectedValue;
+            this.ProtectedInternalProperty = protectedInternalValue;
+            this.InternalProperty = internalValue;
+            this.PrivateProperty = privateValue;
+            this.PrivateProtectedProperty = privateProtectedValue;
         }
 
         [IonPropertyName("Public Property")]

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -483,4 +483,242 @@ namespace Amazon.IonObjectMapper.Test
             return string.Join(Environment.NewLine, dictionary);
         }
     }
+
+    public class ClassWithProperties
+    {
+        public ClassWithProperties() { }
+
+        public ClassWithProperties(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        {
+            this.PublicProperty = PublicProperty;
+            this.DefaultProperty = DefaultProperty;
+            this.ProtectedProperty = ProtectedProperty;
+            this.ProtectedInternalProperty = ProtectedInternalProperty;
+            this.InternalProperty = InternalProperty;
+            this.PrivateProperty = PrivateProperty;
+            this.PrivateProtectedProperty = PrivateProtectedProperty;
+        }
+
+        public string PublicProperty
+        {
+            get;
+            set;
+        }
+
+        string DefaultProperty
+        {
+            get;
+            set;
+        }
+
+        protected string ProtectedProperty
+        {
+            get;
+            set;
+        }
+
+        protected internal string ProtectedInternalProperty
+        {
+            get;
+            set;
+        }
+
+        internal string InternalProperty
+        {
+            get;
+            set;
+        }
+
+        private string PrivateProperty
+        {
+            get;
+            set;
+        }
+
+        private protected string PrivateProtectedProperty
+        {
+            get;
+            set;
+        }
+
+        public string GetPrivateProtectedProperty()
+        {
+            return $"{PrivateProtectedProperty}";
+        }
+
+        public string GetPrivateProperty()
+        {
+            return $"{PrivateProperty}";
+        }
+
+        public string GetProtectedProperty()
+        {
+            return $"{ProtectedProperty}";
+        }
+
+        public string GetDefaultProperty()
+        {
+            return $"{DefaultProperty}";
+        }
+    }
+
+    public class ClassWithReadonlyProperties
+    {
+        public ClassWithReadonlyProperties() { }
+
+        public ClassWithReadonlyProperties(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        {
+            this.PublicProperty = PublicProperty;
+            this.DefaultProperty = DefaultProperty;
+            this.ProtectedProperty = ProtectedProperty;
+            this.ProtectedInternalProperty = ProtectedInternalProperty;
+            this.InternalProperty = InternalProperty;
+            this.PrivateProperty = PrivateProperty;
+            this.PrivateProtectedProperty = PrivateProtectedProperty;
+        }
+
+        public string PublicProperty
+        {
+            get;
+        }
+
+        string DefaultProperty
+        {
+            get;
+        }
+
+        protected string ProtectedProperty
+        {
+            get;
+        }
+
+        protected internal string ProtectedInternalProperty
+        {
+            get;
+        }
+
+        internal string InternalProperty
+        {
+            get;
+        }
+
+        private string PrivateProperty
+        {
+            get;
+        }
+
+        private protected string PrivateProtectedProperty
+        {
+            get;
+        }
+
+        public string GetPrivateProtectedProperty()
+        {
+            return $"{PrivateProtectedProperty}";
+        }
+
+        public string GetPrivateProperty()
+        {
+            return $"{PrivateProperty}";
+        }
+
+        public string GetProtectedProperty()
+        {
+            return $"{ProtectedProperty}";
+        }
+
+        public string GetDefaultProperty()
+        {
+            return $"{DefaultProperty}";
+        }
+    }
+
+
+    public class ClassWithIonPropertyNamesAttribute
+    {
+        public ClassWithIonPropertyNamesAttribute() { }
+
+        public ClassWithIonPropertyNamesAttribute(string PublicProperty, string DefaultProperty, string ProtectedProperty, string ProtectedInternalProperty,
+            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        {
+            this.PublicProperty = PublicProperty;
+            this.DefaultProperty = DefaultProperty;
+            this.ProtectedProperty = ProtectedProperty;
+            this.ProtectedInternalProperty = ProtectedInternalProperty;
+            this.InternalProperty = InternalProperty;
+            this.PrivateProperty = PrivateProperty;
+            this.PrivateProtectedProperty = PrivateProtectedProperty;
+        }
+
+        [IonPropertyName("PublicPropertyz")]
+        public string PublicProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("DefaultPropertyz")]
+        string DefaultProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("ProtectedPropertyz")]
+        protected string ProtectedProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("ProtectedInternalPropertyz")]
+        protected internal string ProtectedInternalProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("InternalPropertyz")]
+        internal string InternalProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("PrivatePropertyz")]
+        private string PrivateProperty
+        {
+            get;
+            set;
+        }
+
+        [IonPropertyName("PrivateProtectedPropertyz")]
+        private protected string PrivateProtectedProperty
+        {
+            get;
+            set;
+        }
+
+        public string GetPrivateProtectedProperty()
+        {
+            return $"{PrivateProtectedProperty}";
+        }
+
+        public string GetPrivateProperty()
+        {
+            return $"{PrivateProperty}";
+        }
+
+        public string GetProtectedProperty()
+        {
+            return $"{ProtectedProperty}";
+        }
+
+        public string GetDefaultProperty()
+        {
+            return $"{DefaultProperty}";
+        }
+    }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -197,10 +197,10 @@ namespace Amazon.IonObjectMapper.Test
         public static ClassWithReadonlyProperties objectWithReadonlyProperties = new ClassWithReadonlyProperties("Public Value", "Protected Value",
             "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
 
-        public static ClassWithIonPropertyNamesAttribute objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute("Public Value", "Protected Value",
+        public static ClassWithIonPropertyNamesAttribute objectWithIonPropertyNameAttributes = new ClassWithIonPropertyNamesAttribute("Public Value", "Protected Value",
             "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
 
-        public static ClassWithMethods objectWithmethods = new ClassWithMethods("Public Value", "Protected Value",
+        public static ClassWithMethods objectWithMethods = new ClassWithMethods("Public Value", "Protected Value",
             "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
     }
 
@@ -533,19 +533,10 @@ namespace Amazon.IonObjectMapper.Test
         private string PrivateProperty { get; set; }
         private protected string PrivateProtectedProperty { get; set; }
 
-        public string GetPrivateProtectedProperty()
+        public override string ToString()
         {
-            return PrivateProtectedProperty;
-        }
-
-        public string GetPrivateProperty()
-        {
-            return PrivateProperty;
-        }
-
-        public string GetProtectedProperty()
-        {
-            return ProtectedProperty;
+            return $"<ClassWithProperties>{{ PublicProperty: {PublicProperty}, ProtectedProperty: {ProtectedProperty}, ProtectedInternalProperty: {ProtectedInternalProperty}, " +
+                   $"InternalProperty: {InternalProperty}, PrivateProperty: {PrivateProperty}, PrivateProtectedProperty: {PrivateProtectedProperty} }}";
         }
     }
 
@@ -571,19 +562,10 @@ namespace Amazon.IonObjectMapper.Test
         private string PrivateProperty { get; }
         private protected string PrivateProtectedProperty { get; }
 
-        public string GetPrivateProtectedProperty()
+        public override string ToString()
         {
-            return PrivateProtectedProperty;
-        }
-
-        public string GetPrivateProperty()
-        {
-            return PrivateProperty;
-        }
-
-        public string GetProtectedProperty()
-        {
-            return ProtectedProperty;
+            return $"<ClassWithReadonlyProperties>{{ PublicProperty: {PublicProperty}, ProtectedProperty: {ProtectedProperty}, ProtectedInternalProperty: {ProtectedInternalProperty}, " +
+                   $"InternalProperty: {InternalProperty}, PrivateProperty: {PrivateProperty}, PrivateProtectedProperty: {PrivateProtectedProperty} }}";
         }
     }
 
@@ -621,19 +603,10 @@ namespace Amazon.IonObjectMapper.Test
         [IonPropertyName("Private Protected Property")]
         private protected string PrivateProtectedProperty { get; set; }
 
-        public string GetPrivateProtectedProperty()
+        public override string ToString()
         {
-            return PrivateProtectedProperty;
-        }
-
-        public string GetPrivateProperty()
-        {
-            return PrivateProperty;
-        }
-
-        public string GetProtectedProperty()
-        {
-            return ProtectedProperty;
+            return $"<ClassWithIonPropertyNamesAttribute>{{ PublicProperty: {PublicProperty}, ProtectedProperty: {ProtectedProperty}, ProtectedInternalProperty: {ProtectedInternalProperty}, " +
+                   $"InternalProperty: {InternalProperty}, PrivateProperty: {PrivateProperty}, PrivateProtectedProperty: {PrivateProtectedProperty} }}";
         }
     }
 
@@ -729,6 +702,12 @@ namespace Amazon.IonObjectMapper.Test
         private protected void SetPrivateProtectedValue(string value)
         {
             this.privateProtectedValue = value;
+        }
+
+        public override string ToString()
+        {
+            return $"<ClassWithMethods>{{ PublicValue: {publicValue}, ProtectedValue: {protectedValue}, ProtectedInternalValue: {protectedInternalValue}, " +
+                   $"InternalValue: {internalValue}, PrivateValue: {privateValue}, PrivateProtectedValue: {privateProtectedValue} }}";
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -496,6 +496,21 @@ namespace Amazon.IonObjectMapper.Test
         }
     }
 
+    public class ClassWithOnlySetProperty
+    {
+        private string val;
+
+        public ClassWithOnlySetProperty(string input)
+        {
+            val = input;
+        }
+
+        public string SetOnlyProperty
+        {
+            set { val = value; }
+        }
+    }
+
     public class ClassWithProperties
     {
         public ClassWithProperties() { }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -569,7 +569,6 @@ namespace Amazon.IonObjectMapper.Test
         }
     }
 
-
     public class ClassWithIonPropertyNamesAttribute
     {
         public ClassWithIonPropertyNamesAttribute() { }
@@ -718,11 +717,11 @@ namespace Amazon.IonObjectMapper.Test
 
     public class ObjectWithPrivateSetter
     {
-        public string field;
+        public string val;
 
         private string Property
         {
-            set { field = value; }
+            set { val = value; }
         }
     }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -710,4 +710,19 @@ namespace Amazon.IonObjectMapper.Test
                    $"InternalValue: {internalValue}, PrivateValue: {privateValue}, PrivateProtectedValue: {privateProtectedValue} }}";
         }
     }
+
+    public class ObjectWithPublicGetter
+    {
+        public string Property { init; get; }
+    }
+
+    public class ObjectWithPrivateSetter
+    {
+        public string field;
+
+        private string Property
+        {
+            set { field = value; }
+        }
+    }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -488,15 +488,15 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithProperties() { }
 
-        public ClassWithProperties(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
-            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        public ClassWithProperties(string publicProperty, string protectedProperty, string protectedInternalProperty,
+            string internalProperty, string privateProperty, string privateProtectedProperty)
         {
-            this.PublicProperty = PublicProperty;
-            this.ProtectedProperty = ProtectedProperty;
-            this.ProtectedInternalProperty = ProtectedInternalProperty;
-            this.InternalProperty = InternalProperty;
-            this.PrivateProperty = PrivateProperty;
-            this.PrivateProtectedProperty = PrivateProtectedProperty;
+            this.PublicProperty = publicProperty;
+            this.ProtectedProperty = protectedProperty;
+            this.ProtectedInternalProperty = protectedInternalProperty;
+            this.InternalProperty = internalProperty;
+            this.PrivateProperty = privateProperty;
+            this.PrivateProtectedProperty = privateProtectedProperty;
         }
 
         public string PublicProperty { get; set; }
@@ -526,15 +526,15 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithReadonlyProperties() { }
 
-        public ClassWithReadonlyProperties(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
-            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        public ClassWithReadonlyProperties(string publicProperty, string protectedProperty, string protectedInternalProperty,
+            string internalProperty, string privateProperty, string privateProtectedProperty)
         {
-            this.PublicProperty = PublicProperty;
-            this.ProtectedProperty = ProtectedProperty;
-            this.ProtectedInternalProperty = ProtectedInternalProperty;
-            this.InternalProperty = InternalProperty;
-            this.PrivateProperty = PrivateProperty;
-            this.PrivateProtectedProperty = PrivateProtectedProperty;
+            this.PublicProperty = publicProperty;
+            this.ProtectedProperty = protectedProperty;
+            this.ProtectedInternalProperty = protectedInternalProperty;
+            this.InternalProperty = internalProperty;
+            this.PrivateProperty = privateProperty;
+            this.PrivateProtectedProperty = privateProtectedProperty;
         }
 
         public string PublicProperty { get; }
@@ -565,14 +565,14 @@ namespace Amazon.IonObjectMapper.Test
     {
         public ClassWithIonPropertyNamesAttribute() { }
 
-        public ClassWithIonPropertyNamesAttribute(string PublicProperty, string ProtectedProperty, string ProtectedInternalProperty,
-            string InternalProperty, string PrivateProperty, string PrivateProtectedProperty)
+        public ClassWithIonPropertyNamesAttribute(string publicProperty, string protectedProperty, string protectedInternalProperty,
+            string internalProperty, string privateProperty, string privateProtectedProperty)
         {
-            this.PublicProperty = PublicProperty;
-            this.ProtectedProperty = ProtectedProperty;
-            this.ProtectedInternalProperty = ProtectedInternalProperty;
-            this.InternalProperty = InternalProperty;
-            this.PrivateProperty = PrivateProperty;
+            this.PublicProperty = publicProperty;
+            this.ProtectedProperty = protectedProperty;
+            this.ProtectedInternalProperty = protectedInternalProperty;
+            this.InternalProperty = internalProperty;
+            this.PrivateProperty = privateProperty;
             this.PrivateProtectedProperty = PrivateProtectedProperty;
         }
 

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -190,6 +190,18 @@ namespace Amazon.IonObjectMapper.Test
             Weight = 52310,
             Capacity = 2230,
         };
+         
+        public static ClassWithProperties objectWithProperties = new ClassWithProperties("Public Property", "Protected Property",
+            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+
+        public static ClassWithReadonlyProperties objectWithReadonlyProperties = new ClassWithReadonlyProperties("Public Property", "Protected Property",
+            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+
+        public static ClassWithIonPropertyNamesAttribute objectWithIonPropertyNames = new ClassWithIonPropertyNamesAttribute("Public Property", "Protected Property",
+            "Protected Internal Property", "Internal Property", "Private Property", "Private Protected Property");
+
+        public static ClassWithMethods objectWithmethods = new ClassWithMethods("Public Value", "Protected Value",
+            "Protected Internal Value", "Internal Value", "Private Value", "Private Protected Value");
     }
 
     public class Car

--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -72,8 +72,7 @@ namespace Amazon.IonObjectMapper.Test
 
         public static void Check<T>(string expectedString, T item)
         {
-            var serializer = new IonSerializer();
-            Assert.AreEqual(expectedString, Serde(serializer, item).ToString());
+            Assert.AreEqual(expectedString, Serde(item).ToString());
         }
 
         public static void AssertHasAnnotation(string annotation, Stream stream)

--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -73,11 +73,6 @@ namespace Amazon.IonObjectMapper.Test
         public static void Check<T>(string expectedString, T item)
         {
             var serializer = new IonSerializer();
-            if (item == null)
-            {
-                Assert.AreEqual(null, Serde(serializer, (object)null));
-                return;
-            }
             Assert.AreEqual(expectedString, Serde(serializer, item).ToString());
         }
 

--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -70,6 +70,17 @@ namespace Amazon.IonObjectMapper.Test
             Assert.AreEqual(item.ToString(), Serde(ionSerializer, item).ToString());
         }
 
+        public static void Check<T>(string expectedString, T item)
+        {
+            var serializer = new IonSerializer();
+            if (item == null)
+            {
+                Assert.AreEqual(null, Serde(serializer, (object)null));
+                return;
+            }
+            Assert.AreEqual(expectedString, Serde(serializer, item).ToString());
+        }
+
         public static void AssertHasAnnotation(string annotation, Stream stream)
         {
             AssertHasAnnotation(annotation, StreamToIonValue(Copy(stream)));

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -276,13 +276,13 @@ namespace Amazon.IonObjectMapper
         }
 
         /// <summary>
-        /// We only serde public, internal, and protected internal properties.
+        /// We only serde public, internal, and protected internal properties or properties with IonPropertyName annotation.
         /// </summary>
         private static bool HasValidAccessModifier(PropertyInfo propertyInfo)
         {
             var methodInfo = propertyInfo.GetGetMethod(true);
 
-            return methodInfo is not null && (methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly);
+            return methodInfo != null && ((methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly)) || propertyInfo.GetCustomAttribute(typeof(IonPropertyName)) != null;
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -282,8 +282,8 @@ namespace Amazon.IonObjectMapper
         {
             var methodInfo = propertyInfo.GetGetMethod(true);
 
-            return methodInfo != null && ((methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly))
-                || propertyInfo.GetCustomAttribute(typeof(IonPropertyName)) != null;
+            return methodInfo != null && (methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly
+                || propertyInfo.GetCustomAttribute(typeof(IonPropertyName)) != null);
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -282,7 +282,8 @@ namespace Amazon.IonObjectMapper
         {
             var methodInfo = propertyInfo.GetGetMethod(true);
 
-            return methodInfo != null && ((methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly)) || propertyInfo.GetCustomAttribute(typeof(IonPropertyName)) != null;
+            return methodInfo != null && ((methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly))
+                || propertyInfo.GetCustomAttribute(typeof(IonPropertyName)) != null;
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -283,11 +283,7 @@ namespace Amazon.IonObjectMapper
         {
             var methodInfo = propertyInfo.GetGetMethod(true);
 
-            if (methodInfo is not null)
-            {
-                return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
-            }
-            return false;
+            return methodInfo is not null && (methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly);
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -178,7 +178,7 @@ namespace Amazon.IonObjectMapper
         private IEnumerable<(MethodInfo, string)> GetGetters()
         {
             var getters = new List<(MethodInfo, string)>();
-            foreach (var method in targetType.GetRuntimeMethods().Where(HasValidAccessModifier))
+            foreach (var method in targetType.GetMethods(BINDINGS))
             {
                 var getMethod = (IonPropertyGetter)method.GetCustomAttribute(typeof(IonPropertyGetter));
                 
@@ -196,7 +196,7 @@ namespace Amazon.IonObjectMapper
         
         private MethodInfo FindSetter(string name)
         {
-            return targetType.GetRuntimeMethods().Where(HasValidAccessModifier).FirstOrDefault(m =>
+            return targetType.GetMethods(BINDINGS).FirstOrDefault(m =>
             {
                 var setMethod = (IonPropertySetter)m.GetCustomAttribute(typeof(IonPropertySetter));
                 return setMethod != null && setMethod.IonPropertyName == name;
@@ -291,14 +291,6 @@ namespace Amazon.IonObjectMapper
             {
                 return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
             }
-        }
-
-        /// <summary>
-        /// We only serde public, internal, and protected internal methods.
-        /// </summary>
-        private static bool HasValidAccessModifier(MethodInfo methodInfo)
-        {
-            return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -178,7 +178,7 @@ namespace Amazon.IonObjectMapper
         private IEnumerable<(MethodInfo, string)> GetGetters()
         {
             var getters = new List<(MethodInfo, string)>();
-            foreach (var method in targetType.GetMethods())
+            foreach (var method in targetType.GetRuntimeMethods().Where(HasValidAccessModifier))
             {
                 var getMethod = (IonPropertyGetter)method.GetCustomAttribute(typeof(IonPropertyGetter));
                 
@@ -196,7 +196,7 @@ namespace Amazon.IonObjectMapper
         
         private MethodInfo FindSetter(string name)
         {
-            return targetType.GetMethods().FirstOrDefault(m =>
+            return targetType.GetRuntimeMethods().Where(HasValidAccessModifier).FirstOrDefault(m =>
             {
                 var setMethod = (IonPropertySetter)m.GetCustomAttribute(typeof(IonPropertySetter));
                 return setMethod != null && setMethod.IonPropertyName == name;
@@ -291,6 +291,14 @@ namespace Amazon.IonObjectMapper
             {
                 return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
             }
+        }
+
+        /// <summary>
+        /// We only serde public, internal, and protected internal methods.
+        /// </summary>
+        private static bool HasValidAccessModifier(MethodInfo methodInfo)
+        {
+            return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -20,7 +20,7 @@ namespace Amazon.IonObjectMapper
             this.options = options;
             this.targetType = targetType;
             this.readOnlyProperties = new Lazy<IEnumerable<PropertyInfo>>(
-                () => this.targetType.GetRuntimeProperties().Where(IsReadOnlyProperty).Where(HasValidAccessModifier));
+                () => this.targetType.GetRuntimeProperties().Where(HasValidAccessModifier).Where(IsReadOnlyProperty));
         }
 
         public override object Deserialize(IIonReader reader)
@@ -283,14 +283,11 @@ namespace Amazon.IonObjectMapper
         {
             var methodInfo = propertyInfo.GetGetMethod(true);
 
-            if (methodInfo is null)
-            {
-                return false;
-            }
-            else
+            if (methodInfo is not null)
             {
                 return methodInfo.IsPublic || methodInfo.IsAssembly || methodInfo.IsFamilyOrAssembly;
             }
+            return false;
         }
 
         private bool IsField(FieldInfo field)

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -20,7 +20,7 @@ namespace Amazon.IonObjectMapper
             this.options = options;
             this.targetType = targetType;
             this.readOnlyProperties = new Lazy<IEnumerable<PropertyInfo>>(
-                () => this.targetType.GetRuntimeProperties().Where(HasValidAccessModifier).Where(IsReadOnlyProperty));
+                () => GetValidProperties().Where(IsReadOnlyProperty));
         }
 
         public override object Deserialize(IIonReader reader)
@@ -110,7 +110,7 @@ namespace Amazon.IonObjectMapper
             }
 
             // Serialize any properties that satisfy the options/attributes.
-            foreach (var property in targetType.GetRuntimeProperties().Where(HasValidAccessModifier))
+            foreach (var property in GetValidProperties())
             {
                 var ionPropertyName = IonFieldNameFromProperty(property);
                 if (serializedIonFields.Contains(ionPropertyName))
@@ -232,8 +232,7 @@ namespace Amazon.IonObjectMapper
 
             if (options.PropertyNameCaseInsensitive)
             {
-                return targetType.GetRuntimeProperties().Where(HasValidAccessModifier).
-                    FirstOrDefault(p => String.Equals(p.Name, readName, StringComparison.OrdinalIgnoreCase));
+                return GetValidProperties().FirstOrDefault(p => String.Equals(p.Name, readName, StringComparison.OrdinalIgnoreCase));
             }
 
             var name = options.NamingConvention.ToProperty(readName);
@@ -309,7 +308,7 @@ namespace Amazon.IonObjectMapper
 
         private IEnumerable<PropertyInfo> IonNamedProperties()
         {
-            return targetType.GetRuntimeProperties().Where(IsIonNamedProperty).Where(HasValidAccessModifier);
+            return GetValidProperties().Where(IsIonNamedProperty);
         }
 
         private string GetFieldName(FieldInfo field)
@@ -320,6 +319,11 @@ namespace Amazon.IonObjectMapper
                 return ((IonPropertyName)propertyName).Name;
             }
             return field.Name;
+        }
+
+        private IEnumerable<PropertyInfo> GetValidProperties()
+        {
+            return targetType.GetRuntimeProperties().Where(HasValidAccessModifier);
         }
     }
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -153,7 +153,7 @@ public class Engine
 }
 ```
 
-the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document. The properties must have public, internal, or protected internal access modifier.
+the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document. The properties must have public, internal, or protected internal access modifiers.
 
 ### Default behavior when deserializing annotated Ion
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -153,7 +153,7 @@ public class Engine
 }
 ```
 
-the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document.
+the `init` keyword is a C# modifier which indicates that the property is only settable at construction time. In reality the Intermediate Language (IL) code just contains a regular setter and so long as properties in general have a getter and setter, the library will be able to use them. By default, all gettable properties will be serialized and all settable properties will be deserialized, but this can be configured as specified later in this document. The properties must have public, internal, or protected internal access modifier.
 
 ### Default behavior when deserializing annotated Ion
 
@@ -278,11 +278,11 @@ public class Car
 }
 ```
 
-If the specified property name conflicts with a field name of the same class, the property will get precedence over the field during serialiation and/or deserialization.
+If the specified property name conflicts with a field name of the same class, the property will get precedence over the field during serialization and/or deserialization. The annotated property can have any access modifier.
 
 ### Methods
 
-By default, C# methods are ignored, however, provided the “get” signature is a no-argument method and the “set” signature is a one-argument `void` method, methods can be use to get and set properties. The Ion property name must be specified and will not be inferred from the method name. In the event of a naming conflict between the specified annotated Ion property name and a property or field name of the class (such as the below example), the annotated Ion property name will get precedence over the class's property or field name during serialization and/or deserialization.
+By default, C# methods are ignored, however, provided the “get” signature is a no-argument method and the “set” signature is a one-argument `void` method, methods can be use to get and set properties. The Ion property name must be specified and will not be inferred from the method name. In the event of a naming conflict between the specified annotated Ion property name and a property or field name of the class (such as the below example), the annotated Ion property name will get precedence over the class's property or field name during serialization and/or deserialization. The annotated method can have any access modifier.
 
 ```c#
 public class Car
@@ -306,7 +306,7 @@ public class Car
 
 ### Fields
 
-By default, C#fields are ignored. However, they can be annotated with an `Attribute` to be included or by an option specified later. Even private fields may be specified.
+By default, C# fields are ignored. However, they can be annotated with an `IonField` `Attribute` to be included or by an option specified later. The annotated field can have any access modifier.
 
 ```c#
 public class Car


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously only public properties were getting serialized/deserialized. To follow the best practice of least astonishment, we now allow internal and protected internal properties to be serialized/deserialized. For properties with annotations, they will be serialized/deserialized regardless of access modifier.

**Note: properties without an access modifier is considered default and it is set to private.** From Microsoft's [Access Modifiers (C# Programming Guide)](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers#class-record-and-struct-accessibility):

> Class and struct members, including nested classes and structs, have private access by default. 

In addition, methods with annotation attributes are serialized/deserialized regardless of access modifier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
