### PR TITLE
Add performance tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release ]
 
 jobs:
   build:
-    name: Build
+    name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,11 +26,15 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
+      - name: Install dependencies
+        run: dotnet restore
       - name: Install Codecov tool
         run: dotnet tool install --global Codecov.Tool --version 1.13.0
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
-      - name: Build, unit test & generate coverage report
-        run: dotnet test --configuration Release --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+      - name: Unit test & generate coverage report
+        run: dotnet test Amazon.IonObjectMapper.Test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v1
@@ -38,3 +42,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
 
+      - name: Performance test
+        if: github.base_ref == 'release'
+        run: dotnet test Amazon.IonObjectMapper.PerformanceTest

--- a/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
+++ b/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.IonObjectMapper\Amazon.IonObjectMapper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
@@ -34,7 +34,7 @@ namespace Amazon.IonObjectMapper.PerformanceTest
             this.metrics.Add(key, new Metric { RuntimeTicks = runtime, MemoryUsedBytes = memoryUsed });
         }
 
-        public bool IsLinearRuntime() 
+        public bool IsLinearRuntime()
         {
             long baseRuntime = this.metrics[this.baselineKey].RuntimeTicks / this.baselineKey;
             Console.WriteLine($"Runtime baseline : {baseRuntime} ticks per entry");
@@ -42,9 +42,10 @@ namespace Amazon.IonObjectMapper.PerformanceTest
             long threshold = Convert.ToInt64(baseRuntime * (1 + (this.errorMargin / 100m)));
             foreach (var kvp in this.metrics)
             {
-                if (kvp.Value.RuntimeTicks / kvp.Key > threshold)
+                long entryCount = kvp.Key;
+                if (kvp.Value.RuntimeTicks / entryCount > threshold)
                 {
-                    Console.WriteLine($"Acceptable runtime threshold of {threshold} ticks exceeded for {kvp.Key} entries : {kvp.Value.RuntimeTicks / kvp.Key} ticks used per entry");
+                    Console.WriteLine($"Acceptable runtime threshold of {threshold} ticks exceeded for {entryCount} entries : {kvp.Value.RuntimeTicks / entryCount} ticks used per entry");
                     return false;
                 }
             }
@@ -52,7 +53,7 @@ namespace Amazon.IonObjectMapper.PerformanceTest
             return true;
         }
 
-        public bool IsLinearMemoryUsed() 
+        public bool IsLinearMemoryUsed()
         {
             long baseMemoryUsed = this.metrics[this.baselineKey].MemoryUsedBytes / this.baselineKey;
             Console.WriteLine($"Memory baseline : {baseMemoryUsed} bytes per entry");
@@ -60,9 +61,10 @@ namespace Amazon.IonObjectMapper.PerformanceTest
             long threshold = Convert.ToInt64(baseMemoryUsed * (1 + (this.errorMargin / 100m)));
             foreach (var kvp in this.metrics)
             {
-                if (kvp.Value.MemoryUsedBytes / kvp.Key > threshold)
+                long entryCount = kvp.Key;
+                if (kvp.Value.MemoryUsedBytes / entryCount > threshold)
                 {
-                    Console.WriteLine($"Acceptable memory threshold of {threshold} bytes exceeded for {kvp.Key} entries : {kvp.Value.MemoryUsedBytes / kvp.Key} bytes used per entry");
+                    Console.WriteLine($"Acceptable memory threshold of {threshold} bytes exceeded for {entryCount} entries : {kvp.Value.MemoryUsedBytes / entryCount} bytes used per entry");
                     return false;
                 }
             }

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.IonObjectMapper.PerformanceTest
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class PerformanceSuite
+    {
+        private long baselineKey;
+        private int errorMargin;
+        private IDictionary<long, Metric> metrics;
+
+        public PerformanceSuite(long baselineKey, int errorMargin)
+        {
+            this.baselineKey = baselineKey;
+            this.errorMargin = errorMargin;
+            this.metrics = new Dictionary<long, Metric>();
+        }
+
+        public void AddMetric(long key, long runtime, long memoryUsed)
+        {
+            this.metrics.Add(key, new Metric { RuntimeTicks = runtime, MemoryUsedBytes = memoryUsed });
+        }
+
+        public bool IsLinearRuntime() 
+        {
+            long baseRuntime = this.metrics[this.baselineKey].RuntimeTicks / this.baselineKey;
+            Console.WriteLine($"Runtime baseline : {baseRuntime} ticks per entry");
+
+            long threshold = Convert.ToInt64(baseRuntime * (1 + (this.errorMargin / 100m)));
+            foreach (var kvp in this.metrics)
+            {
+                if (kvp.Value.RuntimeTicks / kvp.Key > threshold)
+                {
+                    Console.WriteLine($"Acceptable runtime threshold of {threshold} ticks exceeded for {kvp.Key} entries : {kvp.Value.RuntimeTicks / kvp.Key} ticks used per entry");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool IsLinearMemoryUsed() 
+        {
+            long baseMemoryUsed = this.metrics[this.baselineKey].MemoryUsedBytes / this.baselineKey;
+            Console.WriteLine($"Memory baseline : {baseMemoryUsed} bytes per entry");
+
+            long threshold = Convert.ToInt64(baseMemoryUsed * (1 + (this.errorMargin / 100m)));
+            foreach (var kvp in this.metrics)
+            {
+                if (kvp.Value.MemoryUsedBytes / kvp.Key > threshold)
+                {
+                    Console.WriteLine($"Acceptable memory threshold of {threshold} bytes exceeded for {kvp.Key} entries : {kvp.Value.MemoryUsedBytes / kvp.Key} bytes used per entry");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public struct Metric
+    {
+        public long RuntimeTicks { get; init; }
+        public long MemoryUsedBytes { get; init; }
+    }
+
+    public class PerformanceTestObject
+    {
+        public string Name { get; set; }
+        public long Value { get; set; }
+    }
+}

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
@@ -23,24 +23,24 @@ namespace Amazon.IonObjectMapper.PerformanceTest
     public class PerformanceTest
     {
         /// <summary>
-        /// Size of dictionary to use as the baseline for determining how much runtime and 
+        /// Size of dictionary to use as the baseline for determining how much runtime and
         /// memory is required for one entry.
-        /// 
-        /// Setting this to be too low will cause overhead runtime and memory to dominate 
+        ///
+        /// Setting this to be too low will cause overhead runtime and memory to dominate
         /// the per-entry baseline.
         /// </summary>
         private const long BaseCount = 100000;
 
         /// <summary>
-        /// The orders of magnitude to test over the BaseCount amount. 
-        /// 
-        /// For example, a BaseCount of 100,000 with a Magnitude of 2 will test 
-        /// 1,000,000 and 10,000,000 entries.
+        /// The orders of magnitude to test over the BaseCount amount.
+        ///
+        /// For example, a BaseCount of 100,000 with a Magnitude of 2 will test
+        /// 100,000, 1,000,000 and 10,000,000 entries.
         /// </summary>
         private const int Magnitude = 2;
 
         /// <summary>
-        /// Margin of error in percentage to allow over the per-entry baseline. 
+        /// Percentage margin of error to allow over the per-entry baseline.
         /// </summary>
         private const int ErrorMargin = 15;
 

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.IonObjectMapper.PerformanceTest
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+
+    [TestClass]
+    public class PerformanceTest
+    {
+        /// <summary>
+        /// Size of dictionary to use as the baseline for determining how much runtime and 
+        /// memory is required for one entry.
+        /// 
+        /// Setting this to be too low will cause overhead runtime and memory to dominate 
+        /// the per-entry baseline.
+        /// </summary>
+        private const long BaseCount = 100000;
+
+        /// <summary>
+        /// The orders of magnitude to test over the BaseCount amount. 
+        /// 
+        /// For example, a BaseCount of 100,000 with a Magnitude of 2 will test 
+        /// 1,000,000 and 10,000,000 entries.
+        /// </summary>
+        private const int Magnitude = 2;
+
+        /// <summary>
+        /// Margin of error in percentage to allow over the per-entry baseline. 
+        /// </summary>
+        private const int ErrorMargin = 15;
+
+        private static readonly PerformanceSuite suite = new PerformanceSuite(BaseCount, ErrorMargin);
+
+        [TestMethod]
+        public void AssertLinearRuntime()
+        {
+            Assert.IsTrue(suite.IsLinearRuntime());
+        }
+
+        [TestMethod]
+        public void AssertLinearMemoryUsed()
+        {
+            Assert.IsTrue(suite.IsLinearMemoryUsed());
+        }
+
+        [ClassInitialize]
+        public static void RunPerformanceTest(TestContext context)
+        {
+            IList<IDictionary<string, PerformanceTestObject>> dictionaries = new List<IDictionary<string, PerformanceTestObject>>();
+            for (int i = 0; i <= Magnitude; i++)
+            {
+                long dictionarySize = Convert.ToInt64(BaseCount * Math.Pow(10, i));
+                IDictionary<string, PerformanceTestObject> dictionary = new Dictionary<string, PerformanceTestObject>();
+
+                for (long j = 0; j < dictionarySize; j++)
+                {
+                    dictionary.Add(j.ToString(), new PerformanceTestObject { Name = j.ToString(), Value = j });
+                }
+
+                dictionaries.Add(dictionary);
+            }
+
+            foreach (var dictionary in dictionaries)
+            {
+                RecordMetrics(dictionary);
+            }
+        }
+
+        private static void RecordMetrics(IDictionary<string, PerformanceTestObject> dictionary)
+        {
+            IonSerializer serializer = new IonSerializer();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            long baseMemoryUsed = GC.GetTotalMemory(true);
+
+            Stopwatch timer = new Stopwatch();
+
+            timer.Start();
+            Stream serialized = serializer.Serialize(dictionary);
+            dictionary = serializer.Deserialize<Dictionary<string, PerformanceTestObject>>(serialized);
+            timer.Stop();
+
+            long memoryUsed = GC.GetTotalMemory(true) - baseMemoryUsed;
+
+            suite.AddMetric(dictionary.Count, timer.ElapsedTicks, memoryUsed);
+        }
+    }
+}

--- a/ion-object-mapper-dotnet.sln
+++ b/ion-object-mapper-dotnet.sln
@@ -1,11 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.6.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.IonObjectMapper", "Amazon.IonObjectMapper\Amazon.IonObjectMapper.csproj", "{EBF8305D-19B2-4453-B959-07BD3DCFD1C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.IonObjectMapper", "Amazon.IonObjectMapper\Amazon.IonObjectMapper.csproj", "{EBF8305D-19B2-4453-B959-07BD3DCFD1C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.IonObjectMapper.Test", "Amazon.IonObjectMapper.Test\Amazon.IonObjectMapper.Test.csproj", "{28578B03-B942-4658-BD89-C5133458E6AB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.IonObjectMapper.Test", "Amazon.IonObjectMapper.Test\Amazon.IonObjectMapper.Test.csproj", "{28578B03-B942-4658-BD89-C5133458E6AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.IonObjectMapper.PerformanceTest", "Amazon.IonObjectMapper.PerformanceTest\Amazon.IonObjectMapper.PerformanceTest.csproj", "{54446BF2-C621-451E-8B49-C53BE4F83DF6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +16,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EBF8305D-19B2-4453-B959-07BD3DCFD1C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +42,23 @@ Global
 		{28578B03-B942-4658-BD89-C5133458E6AB}.Release|x64.Build.0 = Release|Any CPU
 		{28578B03-B942-4658-BD89-C5133458E6AB}.Release|x86.ActiveCfg = Release|Any CPU
 		{28578B03-B942-4658-BD89-C5133458E6AB}.Release|x86.Build.0 = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Debug|x86.Build.0 = Debug|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|x64.Build.0 = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|x86.ActiveCfg = Release|Any CPU
+		{54446BF2-C621-451E-8B49-C53BE4F83DF6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6894A0D-949C-46B2-B6AD-74662FB1EDB6}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Added performance tests to ensure linear runtime and memory usage for serializing and deserializing Ion.

A GitHub action was added to run the performance tests when creating a pull request to the `release` branch. 

The current configuration round-trips a `Dictionary<string, object>` where the object struct contains a `string` and a `long`. This covers primitive and object serialization, as well as nested serialization and the use of reflection for object types.

By default, 100,000, 1,000,000, and 10,000,000 entries are in the Dictionary to test large file sizes.
