### PR TITLE
Handle readonly property backing field logic during deserialization instead of serialization

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -76,7 +76,7 @@ namespace Amazon.IonObjectMapper.Test
             
             Assert.IsTrue(serialized.ContainsField("firstName"));
             Assert.IsTrue(serialized.ContainsField("lastName"));
-            Assert.IsFalse(serialized.ContainsField("<Major>k__BackingField"));
+            Assert.IsFalse(serialized.ContainsField("major"));
         }
         
         [TestMethod]
@@ -677,12 +677,12 @@ namespace Amazon.IonObjectMapper.Test
         {
             IIonStruct serialized = StreamToIonValue(defaultSerializer.Serialize(TestObjects.objectWithReadonlyProperties));
 
-            Assert.AreEqual("Public Value", serialized.GetField("<PublicProperty>k__BackingField").StringValue);
-            Assert.AreEqual("Protected Internal Value", serialized.GetField("<ProtectedInternalProperty>k__BackingField").StringValue);
-            Assert.AreEqual("Internal Value", serialized.GetField("<InternalProperty>k__BackingField").StringValue);
-            Assert.IsFalse(serialized.ContainsField("<ProtectedProperty>k__BackingField"));
-            Assert.IsFalse(serialized.ContainsField("<PrivateProperty>k__BackingField"));
-            Assert.IsFalse(serialized.ContainsField("<ProtectedPrivateProperty>k__BackingField"));
+            Assert.AreEqual("Public Value", serialized.GetField("publicProperty").StringValue);
+            Assert.AreEqual("Protected Internal Value", serialized.GetField("protectedInternalProperty").StringValue);
+            Assert.AreEqual("Internal Value", serialized.GetField("internalProperty").StringValue);
+            Assert.IsFalse(serialized.ContainsField("protectedProperty"));
+            Assert.IsFalse(serialized.ContainsField("privateProperty"));
+            Assert.IsFalse(serialized.ContainsField("protectedPrivateProperty"));
         }
 
         [TestMethod]

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -23,6 +23,12 @@ namespace Amazon.IonObjectMapper.Test
         }
         
         [TestMethod]
+        public void SerializesAndDeserializesObjectsWithReadOnlyProperties()
+        {
+            Check(TestObjects.JohnGreenwood);
+        }
+        
+        [TestMethod]
         public void SerializesAndDeserializesObjectsWithIncludeFields()
         {
             Check(TestObjects.fieldAcademy, new IonSerializationOptions { IncludeFields = true });

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -382,10 +382,10 @@ namespace Amazon.IonObjectMapper
                 var propertyName = options.NamingConvention.ToProperty(name);
                 if (this.readOnlyProperties.Value.Any(p => p.Name == propertyName))
                 {
-                    exact = targetType.GetField($"<{propertyName}>k__BackingField", BINDINGS);
-                    if (exact != null)
+                    var backingField = targetType.GetField($"<{propertyName}>k__BackingField", BINDINGS);
+                    if (backingField != null)
                     {
-                        return exact;
+                        return backingField;
                     }
                 }
             }

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Amazon.IonDotnet;
 
 namespace Amazon.IonObjectMapper
@@ -277,7 +276,7 @@ namespace Amazon.IonObjectMapper
         {
             // Check if this field is really a backing field for a readonly property and
             // if so, apply the ignore property logic instead of the ignore field logic.
-            if (IsBackingField(field))
+            if (!options.IgnoreReadOnlyProperties && IsBackingFieldForReadonlyProperty(field))
             {
                 return IgnoreDeserializedProperty(deserialized);
             }
@@ -286,9 +285,10 @@ namespace Amazon.IonObjectMapper
                    (options.IgnoreDefaults && deserialized == default);
         }
 
-        private static bool IsBackingField(FieldInfo field)
+        private bool IsBackingFieldForReadonlyProperty(FieldInfo field)
         {
-            return Regex.Match(field.Name, "<[0-9_A-z]+>k__BackingField").Success;
+            var readonlyProperties = this.GetValidProperties(true).Where(IsReadOnlyProperty);
+            return readonlyProperties.Any(p => field.Name == $"<{p.Name}>k__BackingField");
         }
 
         // Compute mapping between parameter names and index in parameter array so we can figure out the

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -251,8 +251,7 @@ namespace Amazon.IonObjectMapper
             if (IsReadOnlyProperty(property))
             {
                 // property.SetValue() does not work with a readonly property.
-                // logic for handling deserializing readonly properties happens during field processing
-                // when we detect backing fields for the property.
+                // To get around this we process the readonly property's backing field instead.
                 return false;
             }
 
@@ -395,6 +394,7 @@ namespace Amazon.IonObjectMapper
             }
             else if (!options.IgnoreReadOnlyProperties)
             {
+                // Check if this field is a backing field for a readonly property.
                 var propertyName = options.NamingConvention.ToProperty(name);
                 var readonlyProperties = this.GetValidProperties(true).Where(IsReadOnlyProperty);
                 if (readonlyProperties.Any(p => p.Name == propertyName))

--- a/Amazon.IonObjectMapper/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/IonObjectSerializer.cs
@@ -246,13 +246,6 @@ namespace Amazon.IonObjectMapper
             // We deserialize whether or not we ultimately use the result because values
             // for some Ion types need to be consumed in order to advance the reader.
             deserialized = ionSerializer.Deserialize(reader, property.PropertyType, ionType);
-            
-            if (IsReadOnlyProperty(property))
-            {
-                // property.SetValue() does not work with a readonly property.
-                // To get around this we process the readonly property's backing field instead.
-                return false;
-            }
 
             return !IgnoreDeserializedProperty(deserialized);
         }


### PR DESCRIPTION
The ordinary deserialization logic does not work for readonly properties. To get around this we had been serializing the backing fields for readonly properties so we can still set the underlying value of the property during deserialization. However this results in those backing fields being inserted (as an extra column) into QLDB whenever the driver does an insert with an object with a readonly property.

ie. 
![image](https://user-images.githubusercontent.com/62349012/123863698-26818700-d8e7-11eb-86e5-bf2c9087039c.png)

Now the readonly property / backing field logic is handled exclusively during deserialization instead of serialization (so the backing field logic is completely hidden from the end users).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.