### PR TITLE
Downgrade .NET Core version requirement to 3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ] # Add other OSes later
-        dotnet: ['3.1.x', '5.0.x']
+        dotnet: ['3.1.x']
 
     steps:
       - name: Git Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ] # Add other OSes later
-        dotnet: ['5.0.x']
+        dotnet: ['3.1.x', '5.0.x']
 
     steps:
       - name: Git Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ] 
-        dotnet: ['3.1.x', '5.0.x']
+        dotnet: ['3.1.x']
 
     steps:
       - name: Git Checkout
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ] 
-        dotnet: ['3.1.x', '5.0.x']
+        dotnet: ['3.1.x']
       
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
@@ -66,7 +66,7 @@ jobs:
           dotnet build --configuration Release
           
           # Push unsigned DLL to S3
-          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.IonObjectMapper/bin/Release/net5.0/Amazon.IonObjectMapper.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.IonObjectMapper/bin/Release/netcoreapp3.1/Amazon.IonObjectMapper.dll  --acl bucket-owner-full-control | jq '.VersionId' )
 
           job_id=""
 
@@ -96,7 +96,7 @@ jobs:
           aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id}
           
           # Get signed DLL from S3
-          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id} Amazon.IonObjectMapper/bin/Release/net5.0/Amazon.IonObjectMapper.dll
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id} Amazon.IonObjectMapper/bin/Release/netcoreapp3.1/Amazon.IonObjectMapper.dll
 
       - name: Publish to NuGet
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ] 
-        dotnet: ['5.0.x']
+        dotnet: ['3.1.x', '5.0.x']
 
     steps:
       - name: Git Checkout
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ] 
-        dotnet: ['5.0.x']
+        dotnet: ['3.1.x', '5.0.x']
       
     steps:
       - uses: aws-actions/configure-aws-credentials@v1

--- a/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
+++ b/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
+++ b/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
+++ b/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceSuite.cs
@@ -75,8 +75,8 @@ namespace Amazon.IonObjectMapper.PerformanceTest
 
     public struct Metric
     {
-        public long RuntimeTicks { get; init; }
-        public long MemoryUsedBytes { get; init; }
+        public long RuntimeTicks { get; set; }
+        public long MemoryUsedBytes { get; set; }
     }
 
     public class PerformanceTestObject

--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
@@ -44,7 +44,7 @@ namespace Amazon.IonObjectMapper.PerformanceTest
         /// </summary>
         private const int ErrorMargin = 15;
 
-        private static readonly PerformanceSuite suite = new(BaseCount, ErrorMargin);
+        private static readonly PerformanceSuite suite = new PerformanceSuite(BaseCount, ErrorMargin);
 
         [TestMethod]
         public void AssertLinearRuntime()
@@ -83,13 +83,13 @@ namespace Amazon.IonObjectMapper.PerformanceTest
 
         private static void RecordMetrics(IDictionary<string, PerformanceTestObject> dictionary)
         {
-            IonSerializer serializer = new();
+            IonSerializer serializer = new IonSerializer();
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
             long baseMemoryUsed = GC.GetTotalMemory(true);
 
-            Stopwatch timer = new();
+            Stopwatch timer = new Stopwatch();
 
             timer.Start();
             Stream serialized = serializer.Serialize(dictionary);

--- a/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
+++ b/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
+++ b/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
+++ b/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -26,7 +26,7 @@ namespace Amazon.IonObjectMapper.Test
     [TestClass]
     public class IonObjectSerializerTest
     {
-        private readonly IonSerializer defaultSerializer = new();
+        private readonly IonSerializer defaultSerializer = new IonSerializer();
         private readonly IValueFactory valueFactory = new ValueFactory();
 
         [TestMethod]
@@ -490,7 +490,7 @@ namespace Amazon.IonObjectMapper.Test
                 {typeof(float), new NegativeFloatIonSerializer()},
             };
 
-            List<object> testList = new(new object[] { "test", 5, 3.14f });
+            List<object> testList = new List<object>(new object[] { "test", 5, 3.14f });
 
             var serialized = (IIonList)SerializeToIonWithCustomSerializers(customSerializers, testList);
 
@@ -510,7 +510,7 @@ namespace Amazon.IonObjectMapper.Test
                 {typeof(float), new NegativeFloatIonSerializer()},
             };
 
-            List<object> testList = new(new object[] { "test", 5, 3.14f });
+            List<object> testList = new List<object>(new object[] { "test", 5, 3.14f });
 
             var deserialized = DeserializeWithCustomSerializers(customSerializers, testList);
 
@@ -604,7 +604,7 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void DeserializeAnnotatedIonToClassNameWithAnnotatedTypeAssemblies()
         {
-            IonSerializationOptions options = new()
+            IonSerializationOptions options = new IonSerializationOptions()
             {
                 AnnotatedTypeAssemblies = new string[]
                 {
@@ -614,7 +614,7 @@ namespace Amazon.IonObjectMapper.Test
 
             IIonReader reader = IonReaderBuilder.Build(TestObjects.truckIonText);
 
-            IonSerializer ionSerializer = new(options);
+            IonSerializer ionSerializer = new IonSerializer(options);
             Vehicle truck = ionSerializer.Deserialize<Vehicle>(reader);
 
             AssertIsTruck(truck);

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -45,7 +45,7 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Plane : Vehicle
     {
-        public int MaxCapacity { get; init; }
+        public int MaxCapacity { get; set; }
 
         public override string ToString()
         {
@@ -65,7 +65,7 @@ namespace Amazon.IonObjectMapper.Test
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Motorcycle : Vehicle
     {
-        public string Brand { get; init; }
+        public string Brand { get; set; }
 
         [IonField]
         public string color;
@@ -91,9 +91,9 @@ namespace Amazon.IonObjectMapper.Test
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
     public class Ship : Boat
     {
-        public string Name { get; init; }
-        public int Weight { get; init; }
-        public int Capacity { get; init; }
+        public string Name { get; set; }
+        public int Weight { get; set; }
+        public int Capacity { get; set; }
 
         public override string ToString()
         {
@@ -104,9 +104,9 @@ namespace Amazon.IonObjectMapper.Test
     // For testing case insensitive deserialization.
     public class ShipWithVariedCasing : Boat
     {
-        public string name { get; init; }
-        public double WEIGHT { get; init; }
-        public int CaPaCiTy { get; init; }
+        public string name { get; set; }
+        public double WEIGHT { get; set; }
+        public int CaPaCiTy { get; set; }
 
         public override string ToString()
         {
@@ -225,9 +225,9 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Person
     {
-        public string Name { get; init; }
-        public int Id { get; init; }
-        public Course Course { get; init; }
+        public string Name { get; set; }
+        public int Id { get; set; }
+        public Course Course { get; set; }
 
         public override string ToString()
         {
@@ -238,8 +238,8 @@ namespace Amazon.IonObjectMapper.Test
     [IonSerializer(Factory = typeof(CourseSerializerFactory))]
     public class Course
     {
-        public int Sections { get; init; }
-        public DateTime MeetingTime { get; init; }
+        public int Sections { get; set; }
+        public DateTime MeetingTime { get; set; }
         public override string ToString()
         {
             return "<Course>{ Sections: " + Sections + ", MeetingTime: " + MeetingTime + "}";
@@ -250,16 +250,16 @@ namespace Amazon.IonObjectMapper.Test
     {
         private string color;
 
-        public string Make { get; init; }
-        public string Model { get; init; }
-        public int YearOfManufacture { get; init; }
-        public Engine Engine { get; init; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+        public int YearOfManufacture { get; set; }
+        public Engine Engine { get; set; }
 
         [IonIgnore]
         public double Speed { get { return new Random().NextDouble(); } }
 
         [IonPropertyName("weightInKg")]
-        public double Weight { get; init; }
+        public double Weight { get; set; }
 
         public string GetColor()
         {
@@ -279,8 +279,8 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Engine
     {
-        public int Cylinders { get; init; }
-        public DateTime ManufactureDate { get; init; }
+        public int Cylinders { get; set; }
+        public DateTime ManufactureDate { get; set; }
 
         public override string ToString()
         {
@@ -336,7 +336,7 @@ namespace Amazon.IonObjectMapper.Test
     public class Radio
     {
         [IonPropertyName("broadcastMethod")]
-        public string Band { get; init; }
+        public string Band { get; set; }
 
         public override string ToString()
         {
@@ -346,8 +346,8 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Wheel
     {
-        public string Brand { get; init; }
-        public string Specification { get; init; }
+        public string Brand { get; set; }
+        public string Specification { get; set; }
 
         [IonConstructor]
         public Wheel(
@@ -367,8 +367,8 @@ namespace Amazon.IonObjectMapper.Test
     // For testing multiple annotated constructors.
     public class Tire
     {
-        public string Brand { get; init; }
-        public string Specification { get; init; }
+        public string Brand { get; set; }
+        public string Specification { get; set; }
 
         [IonConstructor]
         public Tire(
@@ -389,8 +389,8 @@ namespace Amazon.IonObjectMapper.Test
     // For testing unannotated constructor parameters.
     public class Windshield
     {
-        public double Length { get; init; }
-        public double Height { get; init; }
+        public double Length { get; set; }
+        public double Height { get; set; }
 
         [IonConstructor]
         public Windshield(double length, double height)
@@ -403,7 +403,7 @@ namespace Amazon.IonObjectMapper.Test
     // For testing serializing and deserializing between different types using an annotated constructor.
     public class CircleRadius
     {
-        public double Radius { get; init; }
+        public double Radius { get; set; }
 
         public CircleRadius(double radius)
         {
@@ -416,7 +416,7 @@ namespace Amazon.IonObjectMapper.Test
     // to create a CircleCircumference.
     public class CircleCircumference
     {
-        public double Circumference { get; init; }
+        public double Circumference { get; set; }
 
         [IonConstructor]
         public CircleCircumference([IonPropertyName("radius")] double radius)
@@ -482,8 +482,8 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Student
     {
-        public string FirstName { get; init; }
-        public string LastName { get; init; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
         public string Major { get; }
 
         public Student()
@@ -509,8 +509,8 @@ namespace Amazon.IonObjectMapper.Test
     public class Desk
     {
         internal int width;
-        public int Depth { get; init; }
-        public int Height { get; init; }
+        public int Depth { get; set; }
+        public int Height { get; set; }
 
         [IonPropertyGetter("desk width")]
         public int GetWidth()
@@ -577,29 +577,29 @@ namespace Amazon.IonObjectMapper.Test
 
     public class Country
     {
-        public string Name { get; init; }
-        public City Capital { get; init; }
-        public Politician President { get; init; }
-        public List<State> States { get; init; }
+        public string Name { get; set; }
+        public City Capital { get; set; }
+        public Politician President { get; set; }
+        public List<State> States { get; set; }
     }
 
     public class State
     {
-        public string Name { get; init; }
-        public City Capital { get; init; }
-        public Politician Governor { get; init; }
+        public string Name { get; set; }
+        public City Capital { get; set; }
+        public Politician Governor { get; set; }
     }
 
     public class City
     {
-        public string Name { get; init; }
-        public Politician Mayor { get; init; }
+        public string Name { get; set; }
+        public Politician Mayor { get; set; }
     }
 
     public class Politician
     {
-        public string FirstName { get; init; }
-        public string LastName { get; init; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
     }
 
     public class TestDictionary : Dictionary<string, int>
@@ -826,7 +826,7 @@ namespace Amazon.IonObjectMapper.Test
 
     public class ObjectWithPublicGetter
     {
-        public string Property { init; get; }
+        public string Property { set; get; }
     }
 
     public class ObjectWithPrivateSetter

--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>0.1.0</Version>

--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>0.1.0</Version>

--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>0.1.0</Version>

--- a/Amazon.IonObjectMapper/Attribute/IonAnnotateTypeAttribute.cs
+++ b/Amazon.IonObjectMapper/Attribute/IonAnnotateTypeAttribute.cs
@@ -24,7 +24,7 @@ namespace Amazon.IonObjectMapper
         /// Gets a value indicating whether any classes descending from the annotated class
         /// are excluded from the annotation.
         /// </summary>
-        public bool ExcludeDescendants { get; init; }
+        public bool ExcludeDescendants { get; set; }
 
         /// <summary>
         /// Gets or sets the .NET namespace of the annotated type.

--- a/Amazon.IonObjectMapper/Attribute/IonDoNotAnnotateTypeAttribute.cs
+++ b/Amazon.IonObjectMapper/Attribute/IonDoNotAnnotateTypeAttribute.cs
@@ -25,6 +25,6 @@ namespace Amazon.IonObjectMapper
         /// Gets a value indicating whether any classes descending from the annotated class
         /// are excluded from the IonAnnotateTypeAttribute annotation.
         /// </summary>
-        public bool ExcludeDescendants { get; init; }
+        public bool ExcludeDescendants { get; set; }
     }
 }

--- a/Amazon.IonObjectMapper/Attribute/IonSerializerAttribute.cs
+++ b/Amazon.IonObjectMapper/Attribute/IonSerializerAttribute.cs
@@ -25,12 +25,12 @@ namespace Amazon.IonObjectMapper
         /// Gets the name of the IonSerializer Attribute to be used
         /// to create IonSerializerFactory with custom context.
         /// </summary>
-        public Type Factory { get; init; }
+        public Type Factory { get; set; }
 
         /// <summary>
         /// Gets the name of the IonSerializer Attribute to be used
         /// to create custom IonSerializer.
         /// </summary>
-        public Type Serializer { get; init; }
+        public Type Serializer { get; set; }
     }
 }

--- a/Amazon.IonObjectMapper/IonSerializationOptions.cs
+++ b/Amazon.IonObjectMapper/IonSerializationOptions.cs
@@ -25,108 +25,108 @@ namespace Amazon.IonObjectMapper
         /// <summary>
         /// Gets option to specify the .NET property naming convention.
         /// </summary>
-        public IIonPropertyNamingConvention NamingConvention { get; init; } = new CamelCaseNamingConvention();
+        public IIonPropertyNamingConvention NamingConvention { get; set; } = new CamelCaseNamingConvention();
 
         /// <summary>
         /// Gets option to specify the serialization format.
         /// </summary>
-        public IonSerializationFormat Format { get; init; } = TEXT;
+        public IonSerializationFormat Format { get; set; } = TEXT;
 
         /// <summary>
         /// Gets option to specify the maximum deserialization depth.
         /// </summary>
-        public int MaxDepth { get; init; } = 64;
+        public int MaxDepth { get; set; } = 64;
 
         /// <summary>
         /// Gets a value indicating whether to annotate Guids.
         /// </summary>
-        public bool AnnotateGuids { get; init; } = false;
+        public bool AnnotateGuids { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether all .NET fields should be included
         /// during serialization and/or deserialization.
         /// </summary>
-        public bool IncludeFields { get; init; } = false;
+        public bool IncludeFields { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether null values should be ignored during serialization/deserialization.
         /// </summary>
-        public bool IgnoreNulls { get; init; } = false;
+        public bool IgnoreNulls { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether readonly fields should be ignored during serialization/deserialization.
         /// </summary>
-        public bool IgnoreReadOnlyFields { get; init; } = false;
+        public bool IgnoreReadOnlyFields { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether readonly properties should be ignored during serialization/deserialization.
         /// </summary>
-        public bool IgnoreReadOnlyProperties { get; init; } = false;
+        public bool IgnoreReadOnlyProperties { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether property names should be treated as case insensitive.
         /// </summary>
-        public bool PropertyNameCaseInsensitive { get; init; } = false;
+        public bool PropertyNameCaseInsensitive { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether default values should be ignored during serialization/deserialization.
         /// </summary>
-        public bool IgnoreDefaults { get; init; } = false;
+        public bool IgnoreDefaults { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether type information on all non-primitive fields should be included.
         /// </summary>
-        public bool IncludeTypeInformation { get; init; } = false;
+        public bool IncludeTypeInformation { get; set; } = false;
 
         /// <summary>
         /// Gets option to specify the type annotation prefix.
         /// </summary>
-        public ITypeAnnotationPrefix TypeAnnotationPrefix { get; init; } = new NamespaceTypeAnnotationPrefix();
+        public ITypeAnnotationPrefix TypeAnnotationPrefix { get; set; } = new NamespaceTypeAnnotationPrefix();
 
         /// <summary>
         /// Gets option to specify the type annotation .NET class name.
         /// </summary>
-        public ITypeAnnotationName TypeAnnotationName { get; init; } = new ClassNameTypeAnnotationName();
+        public ITypeAnnotationName TypeAnnotationName { get; set; } = new ClassNameTypeAnnotationName();
 
         /// <summary>
         /// Gets option to specify the mapping between the .NET type name and the Ion annotation.
         /// </summary>
-        public IAnnotationConvention AnnotationConvention { get; init; } = new DefaultAnnotationConvention();
+        public IAnnotationConvention AnnotationConvention { get; set; } = new DefaultAnnotationConvention();
 
         /// <summary>
         /// Gets option to specify how a type is annotated during serialization.
         /// </summary>
-        public ITypeAnnotator TypeAnnotator { get; init; } = new DefaultTypeAnnotator();
+        public ITypeAnnotator TypeAnnotator { get; set; } = new DefaultTypeAnnotator();
 
         /// <summary>
         /// Gets option to specify how Ion Readers should be built.
         /// </summary>
-        public IIonReaderFactory ReaderFactory { get; init; } = new DefaultIonReaderFactory();
+        public IIonReaderFactory ReaderFactory { get; set; } = new DefaultIonReaderFactory();
 
         /// <summary>
         /// Gets option to specify how Ion Writers should be built.
         /// </summary>
-        public IIonWriterFactory WriterFactory { get; init; } = new DefaultIonWriterFactory();
+        public IIonWriterFactory WriterFactory { get; set; } = new DefaultIonWriterFactory();
 
         /// <summary>
         /// Gets option to specify how objects should be built during deserialization.
         /// </summary>
-        public IObjectFactory ObjectFactory { get; init; } = new DefaultObjectFactory();
+        public IObjectFactory ObjectFactory { get; set; } = new DefaultObjectFactory();
 
         /// <summary>
         /// Gets option to specify the list of assembly names to search when creating types from annotations.
         /// </summary>
-        public IEnumerable<string> AnnotatedTypeAssemblies { get; init; }
+        public IEnumerable<string> AnnotatedTypeAssemblies { get; set; }
 
         /// <summary>
         /// Gets option to specify custom serializers for any given type.
         /// </summary>
-        public Dictionary<Type, IIonSerializer> IonSerializers { get; init; }
+        public Dictionary<Type, IIonSerializer> IonSerializers { get; set; }
 
         /// <summary>
         /// Gets option to specify a custom context object to be used by custom serializers
         /// to further customize behavior.
         /// </summary>
-        public Dictionary<string, object> CustomContext { get; init; }
+        public Dictionary<string, object> CustomContext { get; set; }
     }
 }

--- a/Amazon.IonObjectMapper/IonSerializer.cs
+++ b/Amazon.IonObjectMapper/IonSerializer.cs
@@ -182,12 +182,12 @@ namespace Amazon.IonObjectMapper
                 return;
             }
 
-            Type genericDictionaryType = item.GetType().GetInterfaces().FirstOrDefault(t => t.GetGenericTypeDefinition().IsAssignableTo(typeof(IDictionary<,>)));
+            Type genericDictionaryType = item.GetType().GetInterfaces().FirstOrDefault(t => typeof(IDictionary<,>).IsAssignableFrom(t.GetGenericTypeDefinition()));
             if (genericDictionaryType != null)
             {
                 var genericArguments = genericDictionaryType.GetGenericArguments();
 
-                if (genericArguments[0].IsAssignableTo(typeof(string)))
+                if (typeof(string).IsAssignableFrom(genericArguments[0]))
                 {
                     new IonDictionarySerializer(this, genericArguments[1]).Serialize(writer, (IDictionary)item);
                     return;
@@ -323,7 +323,7 @@ namespace Amazon.IonObjectMapper
             if (ionType == IonType.Blob)
             {
                 if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
-                    || type.IsAssignableTo(typeof(Guid)))
+                    || typeof(Guid).IsAssignableFrom(type))
                 {
                     var serializer = this.GetPrimitiveSerializer<Guid>(new IonGuidSerializer(this.options));
                     return serializer.Deserialize(reader);
@@ -368,7 +368,7 @@ namespace Amazon.IonObjectMapper
                 if (type.IsGenericType && type.GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)))
                 {
                     var genericArguments = type.GetGenericArguments();
-                    if (genericArguments[0].IsAssignableTo(typeof(string)))
+                    if (typeof(string).IsAssignableFrom(genericArguments[0]))
                     {
                         var dictionarySerializer = new IonDictionarySerializer(this, genericArguments[1]);
                         var deserialized = dictionarySerializer.Deserialize(reader);
@@ -407,7 +407,7 @@ namespace Amazon.IonObjectMapper
                 return new IonListSerializer(this, listType, listType.GetElementType());
             }
 
-            if (listType.IsAssignableTo(typeof(System.Collections.IList)))
+            if (typeof(System.Collections.IList).IsAssignableFrom(listType))
             {
                 if (listType.IsGenericType)
                 {


### PR DESCRIPTION
*Description of changes:*

* Remove C# 9 and .NET 5 features including `init` keyword, Target-typed New Expressions, [Type.IsAssignableTo(Type) Method](https://docs.microsoft.com/en-us/dotnet/api/system.type.isassignableto?view=net-5.0) to allow downgrade .NET Core version requirement to 3.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
