### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Amazon Web Services</Authors>
     <Company>Amazon.com, Inc.</Company>
     <Product>Amazon Ion Object Mapper</Product>


### PR DESCRIPTION
*Description of changes:*
Bump version to `0.1.1` to prepare the release for ObjectMapper that uses .NET Core 3.1 instead of .NET 5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
