### PR TITLE
Adjust test parameters to increase stability

### DIFF
--- a/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
+++ b/Amazon.IonObjectMapper.PerformanceTest/PerformanceTest.cs
@@ -29,7 +29,7 @@ namespace Amazon.IonObjectMapper.PerformanceTest
         /// Setting this to be too low will cause overhead runtime and memory to dominate
         /// the per-entry baseline.
         /// </summary>
-        private const long BaseCount = 100000;
+        private const long BaseCount = 10000;
 
         /// <summary>
         /// The orders of magnitude to test over the BaseCount amount.
@@ -42,7 +42,7 @@ namespace Amazon.IonObjectMapper.PerformanceTest
         /// <summary>
         /// Percentage margin of error to allow over the per-entry baseline.
         /// </summary>
-        private const int ErrorMargin = 15;
+        private const int ErrorMargin = 30;
 
         private static readonly PerformanceSuite suite = new PerformanceSuite(BaseCount, ErrorMargin);
 


### PR DESCRIPTION
*Description of changes:*

Currently the performance test will serde a dictionary with size of 100,000, calculate the average time and memory used to serde one entry in the dictionary as base performance. Then it will serde dictionaries with size of 1,000,000 and 10,000,000 and assert that the time and memory used to serde one entry in the dictionary is within 15% error margin of the base performance.

Currently the test will take about 10 minutes to finish on my local machine and sometimes will fail because the time is used is not within the 15% error margin. Example:
```
Runtime baseline : 42368 ticks per entry
Acceptable runtime threshold of 48723 ticks exceeded for 10000000 entries : 49434 ticks used per entry
```
The 10,000,000 dictionary took about 16.67% more time than the base and will fail the test. To fix this we could increase the default error margin to make the test more stable and decrease the default dictionary size to make the test faster to succeed/fail. Note that we could always customize the error margin and dictionary size locally to do more perf testing if we want, but for the default one, current settings are not easy to use to just verify the basic functionality of the ObjectMapper.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
