### PR TITLE
Respect Format option during serialization

### DIFF
--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -164,6 +164,14 @@ namespace Amazon.IonObjectMapper.Test
             Course = new Course { Sections = 10, MeetingTime = DateTime.Parse("2009-10-10T13:15:21Z") }
         };
 
+        public static Person John = new Person
+        {
+            Name = "John",
+            Id = 13
+        };
+
+        public static string JohnIonText = "{name:\"John\",id:13,course:null}";
+
         public static Truck nativeTruck = new Truck();
 
         public static string truckIonText = "Truck:: { }";

--- a/Amazon.IonObjectMapper/Factory/DefaultIonWriterFactory.cs
+++ b/Amazon.IonObjectMapper/Factory/DefaultIonWriterFactory.cs
@@ -24,36 +24,17 @@ namespace Amazon.IonObjectMapper
     /// </summary>
     public class DefaultIonWriterFactory : IIonWriterFactory
     {
-        private readonly IonSerializationFormat format = TEXT;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultIonWriterFactory"/> class.
-        /// </summary>
-        public DefaultIonWriterFactory()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultIonWriterFactory"/> class.
-        /// </summary>
-        ///
-        /// <param name="format">Serialization format.</param>
-        public DefaultIonWriterFactory(IonSerializationFormat format)
-        {
-            this.format = format;
-        }
-
         /// <inheritdoc/>
-        public IIonWriter Create(Stream stream)
+        public IIonWriter Create(IonSerializationOptions options, Stream stream)
         {
-            return this.format switch
+            return options.Format switch
             {
                 BINARY => IonBinaryWriterBuilder.Build(stream),
                 TEXT => IonTextWriterBuilder.Build(new StreamWriter(stream)),
                 PRETTY_TEXT => IonTextWriterBuilder.Build(
                     new StreamWriter(stream),
                     new IonTextOptions { PrettyPrint = true }),
-                _ => throw new InvalidOperationException($"Format {this.format} not supported"),
+                _ => throw new InvalidOperationException($"Format {options.Format} not supported"),
             };
         }
     }

--- a/Amazon.IonObjectMapper/Factory/IIonWriterFactory.cs
+++ b/Amazon.IonObjectMapper/Factory/IIonWriterFactory.cs
@@ -24,10 +24,10 @@ namespace Amazon.IonObjectMapper
         /// <summary>
         /// Create an Ion Writer.
         /// </summary>
-        ///
+        /// <param name="options">Serialization options for customizing serializer behavior.</param>
         /// <param name="stream">The stream to be written by the Ion writer.</param>
         ///
         /// <returns>The created Ion reader.</returns>
-        IIonWriter Create(Stream stream);
+        IIonWriter Create(IonSerializationOptions options, Stream stream);
     }
 }

--- a/Amazon.IonObjectMapper/IonSerializer.cs
+++ b/Amazon.IonObjectMapper/IonSerializer.cs
@@ -71,10 +71,10 @@ namespace Amazon.IonObjectMapper
         /// <typeparam name="T">The type of data to serialize.</typeparam>
         public void Serialize<T>(Stream stream, T item)
         {
-            IIonWriter writer = this.options.WriterFactory.Create(stream);
+            IIonWriter writer = this.options.WriterFactory.Create(this.options, stream);
             this.Serialize(writer, item);
-            writer.Finish();
             writer.Flush();
+            writer.Finish();
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [0.1.3] - Unreleased
 
+### Fixed
+- The `Format` option will be valued by ObjectMapper now (#56)
+
 ## [0.1.2] - 2021-10-29
 
 ### Fixed


### PR DESCRIPTION
*Issue #, if available:*
#56 
*Description of changes:*
The `format` field in `DefaultIonWriterFactory` class will never be set after initialization, which will cause the ObjectMapper always use Ion text format for serialization without respecting the `Format` option. Adding `IonSerializationOption` parameter to the Ion writer factory will let the ObjectMapper respect `Format` option during serialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
