### PR TITLE
Change default serialization format to Ion binary

### DIFF
--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -18,6 +18,7 @@ namespace Amazon.IonObjectMapper.Test
     using System.IO;
     using System.Linq;
     using System.Text;
+    using Amazon.IonDotnet;
     using Amazon.IonDotnet.Builders;
     using Amazon.IonDotnet.Tree;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -80,6 +81,15 @@ namespace Amazon.IonObjectMapper.Test
                 Assert.AreEqual(null, Serde(ionSerializer, (object) null));
                 return;
             }
+            
+            // According to [Ion equivalence](https://amzn.github.io/ion-docs/guides/symbols-guide.html#symboltoken-equivalence),
+            // SymbolTokens with the same text are equivalent
+            if (item is SymbolToken symbolToken)
+            {
+                Assert.IsTrue(symbolToken.IsEquivalentTo(Serde(ionSerializer, symbolToken)));
+                return;
+            }
+
             Assert.AreEqual(item.ToString(), Serde(ionSerializer, item).ToString());
         }
 

--- a/Amazon.IonObjectMapper/IonSerializationOptions.cs
+++ b/Amazon.IonObjectMapper/IonSerializationOptions.cs
@@ -30,7 +30,7 @@ namespace Amazon.IonObjectMapper
         /// <summary>
         /// Gets option to specify the serialization format.
         /// </summary>
-        public IonSerializationFormat Format { get; set; } = TEXT;
+        public IonSerializationFormat Format { get; set; } = BINARY;
 
         /// <summary>
         /// Gets option to specify the maximum deserialization depth.

--- a/Amazon.IonObjectMapper/IonSerializer.cs
+++ b/Amazon.IonObjectMapper/IonSerializer.cs
@@ -73,8 +73,12 @@ namespace Amazon.IonObjectMapper
         {
             IIonWriter writer = this.options.WriterFactory.Create(this.options, stream);
             this.Serialize(writer, item);
+
+            // We use `IIonWriter.Flush` instead of `IIonWriter.Finish` here. Although the `Finish` method
+            // documentation says "all written values will be flushed", that's only true for Ion binary writer.
+            // For Ion text writer, the `Finish` method is empty and only the `Flush` method calls the implemented
+            // `TextWriter.Flush` method that causes any buffered data to be written to the underlying device.
             writer.Flush();
-            writer.Finish();
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - The `Format` option will be valued by ObjectMapper now (#56)
 
+### Changed
+- Change the default serialization format to Ion binary
+
 ## [0.1.2] - 2021-10-29
 
 ### Fixed


### PR DESCRIPTION
*Description of changes:*
Change default serialization format to Ion binary, which aligns with the [design](https://github.com/amzn/ion-object-mapper-dotnet/blob/main/SPEC.md#serialization-options) and the assumption in driver [serialization library](https://github.com/awslabs/amazon-qldb-driver-dotnet/blob/cf2b61641bc12a29960509114efed217662f4a66/Amazon.QLDB.Driver.Serialization/ObjectSerializer.cs#L64)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
