### PR TITLE
Add support to identify target type from Ion annotation

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -222,19 +222,31 @@ namespace Amazon.IonObjectMapper.Test
         [TestMethod]
         public void SerializesAndDeserializesSubtypesBasedOnTypeAnnotations()
         {
-            Check(
-                new List<Vehicle>()
+            var item = new List<Vehicle>()
+            {
+                new Plane(), new Boat(), new Helicopter()
+            };
+            var serializer = new IonSerializer(new IonSerializationOptions
+            {
+                AnnotatedTypeAssemblies = new string[]
                 {
-                    new Plane(), new Boat(), new Helicopter()
-                },
-                new IonSerializationOptions
-                {
-                    AnnotatedTypeAssemblies = new string[]
-                    {
-                        typeof(Vehicle).Assembly.GetName().Name
-                    }
+                    typeof(Vehicle).Assembly.GetName().Name
                 }
-            );
+            });
+            var deserialized = serializer.Deserialize<List<Vehicle>>(serializer.Serialize(item));
+            Assert.AreEqual(string.Join(",", item), string.Join(",", deserialized));
+        }
+
+        [TestMethod]
+        public void DeserializeBasedOnTypeAnnotations()
+        {
+            var item = new List<Vehicle>()
+            {
+                new Plane{ MaxCapacity = 64 }, new Boat(), new Helicopter()
+            };
+            var serializer = new IonSerializer();
+            var deserialized = serializer.Deserialize<List<Vehicle>>(serializer.Serialize(item));
+            Assert.AreEqual(string.Join(",", item), string.Join(",", deserialized));
         }
 
         [TestMethod]
@@ -698,7 +710,7 @@ namespace Amazon.IonObjectMapper.Test
         {
             // Multiple annotations are ignored, it will only pick the first one.
             IIonValue ionTruck = valueFactory.NewEmptyStruct();
-            ionTruck.AddTypeAnnotation("Truck");
+            ionTruck.AddTypeAnnotation("Amazon.IonObjectMapper.Test.Truck");
             ionTruck.AddTypeAnnotation("SecondAnnotation");
 
             IIonReader reader = IonReaderBuilder.Build(ionTruck);

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -49,7 +49,7 @@ namespace Amazon.IonObjectMapper.Test
 
         public override string ToString()
         {
-            return "<Plane>";
+            return "<Plane>{ " + MaxCapacity + " }";
         }
     }
 
@@ -181,7 +181,7 @@ namespace Amazon.IonObjectMapper.Test
 
         public static Truck nativeTruck = new Truck();
 
-        public static string truckIonText = "Truck:: { }";
+        public static string truckIonText = "'Amazon.IonObjectMapper.Test.Truck'::{}";
 
         public static Registration registration = new Registration(new LicensePlate("KM045F", DateTime.Parse("2020-04-01T12:12:12Z")));
 

--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -158,7 +158,7 @@ namespace Amazon.IonObjectMapper.Test
 
         public static void AssertIsTruck(object actual)
         {
-            Assert.AreEqual(actual.ToString(), TestObjects.nativeTruck.ToString());
+            Assert.AreEqual( TestObjects.nativeTruck.ToString(), actual.ToString());
         }
     }
 }

--- a/Amazon.IonObjectMapper/Factory/DefaultObjectFactory.cs
+++ b/Amazon.IonObjectMapper/Factory/DefaultObjectFactory.cs
@@ -14,7 +14,6 @@
 namespace Amazon.IonObjectMapper
 {
     using System;
-    using System.Reflection;
     using Amazon.IonDotnet;
 
     /// <summary>
@@ -25,46 +24,7 @@ namespace Amazon.IonObjectMapper
         /// <inheritdoc/>
         public object Create(IonSerializationOptions options, IIonReader reader, Type targetType)
         {
-            var annotations = reader.GetTypeAnnotations();
-            if (annotations.Length > 0)
-            {
-                var typeName = annotations[0];
-                Type typeToCreate = null;
-
-                if (options.AnnotatedTypeAssemblies != null)
-                {
-                    foreach (string assemblyName in options.AnnotatedTypeAssemblies)
-                    {
-                        if ((typeToCreate = Type.GetType(FullName(typeName, assemblyName))) != null)
-                        {
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-                    {
-                        typeToCreate = assembly.GetType(assembly.GetName().Name + "." + typeName);
-                        if (typeToCreate != null)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (typeToCreate != null && targetType.IsAssignableFrom(typeToCreate))
-                {
-                    return Activator.CreateInstance(typeToCreate);
-                }
-            }
-
             return Activator.CreateInstance(targetType);
-        }
-
-        private static string FullName(string typeName, string assemblyName)
-        {
-            return assemblyName + "." + typeName + "," + assemblyName;
         }
     }
 }

--- a/Amazon.IonObjectMapper/IonSerializer.cs
+++ b/Amazon.IonObjectMapper/IonSerializer.cs
@@ -271,11 +271,12 @@ namespace Amazon.IonObjectMapper
                 return null;
             }
 
+            var annotations = reader.GetTypeAnnotations();
+
             // The AnnotatedIonSerializers takes precedence over IonSerializerAttribute
             if (this.options.AnnotatedIonSerializers != null)
             {
-                var ionAnnotateTypes = reader.GetTypeAnnotations();
-                foreach (var ionAnnotateType in ionAnnotateTypes)
+                foreach (var ionAnnotateType in annotations)
                 {
                     if (this.options.AnnotatedIonSerializers.ContainsKey(ionAnnotateType))
                     {
@@ -308,7 +309,7 @@ namespace Amazon.IonObjectMapper
 
             if (ionType == IonType.Int)
             {
-                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
+                if (annotations.Any(s => s.Equals(IonLongSerializer.ANNOTATION)))
                 {
                     var serializer = this.GetPrimitiveSerializer<long>(new IonLongSerializer());
                     return serializer.Deserialize(reader);
@@ -322,7 +323,7 @@ namespace Amazon.IonObjectMapper
 
             if (ionType == IonType.Float)
             {
-                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
+                if (annotations.Any(s => s.Equals(IonFloatSerializer.ANNOTATION)))
                 {
                     var serializer = this.GetPrimitiveSerializer<float>(new IonFloatSerializer());
                     return serializer.Deserialize(reader);
@@ -336,7 +337,7 @@ namespace Amazon.IonObjectMapper
 
             if (ionType == IonType.Decimal)
             {
-                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
+                if (annotations.Any(s => s.Equals(IonDecimalSerializer.ANNOTATION)))
                 {
                     var serializer = this.GetPrimitiveSerializer<decimal>(new IonDecimalSerializer());
                     return serializer.Deserialize(reader);
@@ -350,7 +351,7 @@ namespace Amazon.IonObjectMapper
 
             if (ionType == IonType.Blob)
             {
-                if (reader.GetTypeAnnotations().Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
+                if (annotations.Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
                     || typeof(Guid).IsAssignableFrom(type))
                 {
                     var serializer = this.GetPrimitiveSerializer<Guid>(new IonGuidSerializer(this.options));

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -67,7 +67,7 @@ namespace Amazon.IonObjectMapper
                 {
                     foreach (string assemblyName in this.options.AnnotatedTypeAssemblies)
                     {
-                        if ((typeToCreate = Type.GetType(FullName(typeName, assemblyName))) != null)
+                        if ((typeToCreate = Type.GetType(this.FullName(typeName, assemblyName))) != null)
                         {
                             break;
                         }


### PR DESCRIPTION
*Issue #, if available:*
#59 
*Description of changes:*
- Add support to identify target type from Ion annotation for deserialization
- Fix tests to compare the actual content of the List

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
