### PR TITLE
Add support for IonAnnotateType attribute to work on Property

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -350,6 +350,37 @@ namespace Amazon.IonObjectMapper.Test
         }
 
         [TestMethod]
+        public void RespectTypeAnnotationForProperty()
+        {
+            var serializer = new IonSerializer();
+            var testStream = serializer.Serialize(TestObjects.a90);
+            var ionValue = StreamToIonValue(Copy(testStream));
+            Assert.IsTrue(ionValue.GetField("brand").HasAnnotation("OEM.Manufacturer"));
+
+            var deserialized = serializer.Deserialize<Supra>(testStream);
+            Assert.AreEqual(TestObjects.a90.ToString(), deserialized.ToString());
+        }
+
+        [TestMethod]
+        public void RespectTypeAnnotationForClassAndProperty()
+        {
+            var serializer = new IonSerializer();
+            var testStream = serializer.Serialize(TestObjects.honda);
+            var ionValue = StreamToIonValue(Copy(testStream));
+            string[] actualAnnotations = ionValue.GetField("engine").GetTypeAnnotationSymbols()
+                .Select(symbolToken => symbolToken.Text).ToArray();
+            string[] expectedAnnotations =
+            {
+                "Amazon.IonObjectMapper.Test.my.custom.engine.type",
+                "Amazon.IonObjectMapper.Test.Engine"
+            };
+            Assert.AreEqual(string.Join(",", expectedAnnotations), string.Join(",", actualAnnotations));
+
+            var deserialized = serializer.Deserialize<Car>(testStream);
+            Assert.AreEqual(TestObjects.honda.ToString(), deserialized.ToString());
+        }
+
+        [TestMethod]
         public void SerializesWithCustomBoolSerializer()
         {
             var serialized = SerializeToIonWithCustomSerializer(new NegationBoolIonSerializer(), true);

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -159,6 +159,11 @@ namespace Amazon.IonObjectMapper.Test
     {
         [IonAnnotateType(Name = "Manufacturer", Prefix = "OEM")]
         public string Brand { get; set; } = "Toyota";
+
+        public override string ToString()
+        {
+            return "<Supra>{ " + Brand + " }";
+        }
     }
 
     [IonDoNotAnnotateType(ExcludeDescendants = true)]
@@ -351,6 +356,8 @@ namespace Amazon.IonObjectMapper.Test
         public string Make { get; set; }
         public string Model { get; set; }
         public int YearOfManufacture { get; set; }
+
+        [IonAnnotateType(Name = "my.custom.engine.type")]
         public Engine Engine { get; set; }
 
         [IonIgnore]
@@ -371,10 +378,11 @@ namespace Amazon.IonObjectMapper.Test
 
         public override string ToString()
         {
-            return "<Car>{ Make: " + Make + ", Model: " + Model + ", YearOfManufacture: " + YearOfManufacture + " }";
+            return $"<Car>{{Make: {Make}, Model: {Model}, YearOfManufacture: {YearOfManufacture}, Engine: {Engine}, Weight: {Weight} }}";
         }
     }
 
+    [IonAnnotateType]
     public class Engine
     {
         public int Cylinders { get; set; }

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -264,7 +264,9 @@ namespace Amazon.IonObjectMapper
                         continue;
                     }
 
-                    writer.AddTypeAnnotation(this.options.AnnotationConvention.Apply(this.options, ionAnnotateType, property.PropertyType));
+                    // Use the actual type of property at runtime to handle dynamic type
+                    var propertyType = propertyValue != null ? propertyValue.GetType() : property.PropertyType;
+                    writer.AddTypeAnnotation(this.options.AnnotationConvention.Apply(this.options, ionAnnotateType, propertyType));
                 }
 
                 this.ionSerializer.Serialize(writer, propertyValue);

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -256,10 +256,15 @@ namespace Amazon.IonObjectMapper
                 }
 
                 writer.SetFieldName(ionPropertyName);
-                var ionAnnotateTypes = (IEnumerable<IonAnnotateTypeAttribute>)property.GetCustomAttributes(typeof(IonAnnotateTypeAttribute));
-                if (this.ionSerializer.TryAnnotatedIonSerializer(writer, propertyValue, ionAnnotateTypes))
+                var ionAnnotateType = (IonAnnotateTypeAttribute)Attribute.GetCustomAttribute(property, typeof(IonAnnotateTypeAttribute), false);
+                if (ionAnnotateType != null)
                 {
-                    continue;
+                    if (this.ionSerializer.TryAnnotatedIonSerializer(writer, propertyValue, ionAnnotateType))
+                    {
+                        continue;
+                    }
+
+                    writer.AddTypeAnnotation(this.options.AnnotationConvention.Apply(this.options, ionAnnotateType, property.PropertyType));
                 }
 
                 this.ionSerializer.Serialize(writer, propertyValue);
@@ -292,8 +297,8 @@ namespace Amazon.IonObjectMapper
                 }
 
                 writer.SetFieldName(ionFieldName);
-                var ionAnnotateTypes = (IEnumerable<IonAnnotateTypeAttribute>)field.GetCustomAttributes(typeof(IonAnnotateTypeAttribute));
-                if (this.ionSerializer.TryAnnotatedIonSerializer(writer, fieldValue, ionAnnotateTypes))
+                var ionAnnotateType = (IonAnnotateTypeAttribute)Attribute.GetCustomAttribute(field, typeof(IonAnnotateTypeAttribute), false);
+                if (ionAnnotateType != null && this.ionSerializer.TryAnnotatedIonSerializer(writer, fieldValue, ionAnnotateType))
                 {
                     continue;
                 }

--- a/Amazon.IonObjectMapper/TypeAnnotation/DefaultAnnotationConvention.cs
+++ b/Amazon.IonObjectMapper/TypeAnnotation/DefaultAnnotationConvention.cs
@@ -21,8 +21,10 @@ namespace Amazon.IonObjectMapper
     public class DefaultAnnotationConvention : IAnnotationConvention
     {
         /// <inheritdoc/>
-        public string Apply(IonAnnotateTypeAttribute annotateType, Type type)
+        public string Apply(IonSerializationOptions options, IonAnnotateTypeAttribute annotateType, Type type)
         {
+            annotateType.Prefix ??= options.TypeAnnotationPrefix.Apply(type);
+            annotateType.Name ??= options.TypeAnnotationName.Apply(type);
             return annotateType.Prefix + "." + annotateType.Name;
         }
     }

--- a/Amazon.IonObjectMapper/TypeAnnotation/DefaultTypeAnnotator.cs
+++ b/Amazon.IonObjectMapper/TypeAnnotation/DefaultTypeAnnotator.cs
@@ -33,9 +33,7 @@ namespace Amazon.IonObjectMapper
 
             if (annotateType != null)
             {
-                annotateType.Prefix ??= options.TypeAnnotationPrefix.Apply(type);
-                annotateType.Name ??= options.TypeAnnotationName.Apply(type);
-                writer.AddTypeAnnotation(options.AnnotationConvention.Apply(annotateType, type));
+                writer.AddTypeAnnotation(options.AnnotationConvention.Apply(options, annotateType, type));
             }
         }
 

--- a/Amazon.IonObjectMapper/TypeAnnotation/IAnnotationConvention.cs
+++ b/Amazon.IonObjectMapper/TypeAnnotation/IAnnotationConvention.cs
@@ -24,10 +24,11 @@ namespace Amazon.IonObjectMapper
         /// Apply annotation convention.
         /// </summary>
         ///
+        /// <param name="options">Serialization options for customizing serializer behavior.</param>
         /// <param name="annotateType">Type to annotate.</param>
         /// <param name="type">.NET Type being annotated.</param>
         ///
         /// <returns>Annotated name.</returns>
-        public string Apply(IonAnnotateTypeAttribute annotateType, Type type);
+        public string Apply(IonSerializationOptions options, IonAnnotateTypeAttribute annotateType, Type type);
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## [0.1.3] - Unreleased
 
+### Added
+- Add support to identify target type from Ion annotation for deserialization (#61)
+- Add tests and test objects for scenarios dealing with `IonAnnotateType` (#64)
+- Add support for `IonAnnotateType` attribute to work on Property. (#65)
+
 ### Fixed
 - The `Format` option will be valued by ObjectMapper now (#56)
 
 ### Changed
-- Change the default serialization format to Ion binary
+- Change the default serialization format to Ion binary (#58)
 
 ## [0.1.2] - 2021-10-29
 


### PR DESCRIPTION
*Issue #, if available:*
#62 
*Description of changes:*
Add support for `IonAnnotateType` attribute to work on Property. 

If both _property_ and _property type_ have `IonAnnotateType` attribute. The type annotation of _property_ will write first, then write type annotation of _property type_. 

For deserialization, only the first annotation will be identified as the type annotation for current ion type, thus the type annotation of _property_ will take precedence. https://github.com/amzn/ion-object-mapper-dotnet/blob/67701aaf68b51f417fa27a272ad2174137c31672/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs#L63

For `AnnotatedIonSerializers` option, it will look up all the type annotations for current ion type and use the serializer identified by the first matched annotation. https://github.com/amzn/ion-object-mapper-dotnet/blob/67701aaf68b51f417fa27a272ad2174137c31672/Amazon.IonObjectMapper/IonSerializer.cs#L274-L287 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
