### PR TITLE
Explicitly handle conflicts between IonPropertyName and field names #29

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonObjectSerializerTest.cs
@@ -850,5 +850,23 @@ namespace Amazon.IonObjectMapper.Test
             var deserializedObject = defaultSerializer.Deserialize<ObjectWithPrivateSetter>(stream);
             Assert.IsNull(deserializedObject.val);
         }
+
+        [TestMethod]
+        public void SerializesAndDeserializePropertiesWhenConflictingFieldNamesArePresent()
+        {
+            var stream = defaultSerializer.Serialize(new PropertyNameConflictsWithIonPropertyField
+            {
+                firstString = "ignored",
+                SomeOtherFirstString = "expected"
+            });
+
+            var serialized = StreamToIonValue(stream);
+            Assert.IsFalse(serialized.ContainsField("SomeOtherFirstString"));
+            Assert.IsTrue(serialized.ContainsField("firstString"));
+            Assert.AreEqual(serialized.GetField("firstString").StringValue, "expected");
+
+            var deserialized = defaultSerializer.Deserialize<PropertyNameConflictsWithIonPropertyField>(IonReaderBuilder.Build(serialized));
+            Assert.AreEqual(deserialized.SomeOtherFirstString, "expected");
+        }
     }
 }

--- a/Amazon.IonObjectMapper.Test/TestObjects.cs
+++ b/Amazon.IonObjectMapper.Test/TestObjects.cs
@@ -966,4 +966,13 @@ namespace Amazon.IonObjectMapper.Test
             set { val = value; }
         }
     }
+
+    public class PropertyNameConflictsWithIonPropertyField
+    {
+        [IonField]
+        public string firstString;
+        
+        [IonPropertyName("firstString")]
+        public string SomeOtherFirstString { get; set; }
+    }
 }

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -263,6 +263,7 @@ namespace Amazon.IonObjectMapper
                 }
 
                 this.ionSerializer.Serialize(writer, propertyValue);
+                serializedIonFields.Add(ionPropertyName);
             }
 
             // Serialize any fields that satisfy the options/attributes.


### PR DESCRIPTION
*Issue #, if available:* #29

*Description of changes:*

In order to ensure that `IonPropertyName` is respected over any conflicting field names, this PR adds the `IonPropertyName` value to the list of serialized fields, so that any included fields with the same name are ignored when read.

It appears that the produced object already had this behaviour, since the nested call to `IonSerializer#Serialize` on the field appears later than the property and would not override the previous written value. However, this seemed more like an unintentional success, rather than an explicit handling of this edge case, so I have added the check explicitly here, as well as a unit test for the behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
