### PR TITLE
Fix error when deserializing Ion blob to Nullable<Guid>

### DIFF
--- a/Amazon.IonObjectMapper/IonSerializer.cs
+++ b/Amazon.IonObjectMapper/IonSerializer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
@@ -365,7 +365,8 @@ namespace Amazon.IonObjectMapper
             if (ionType == IonType.Blob)
             {
                 if (annotations.Any(s => s.Equals(IonGuidSerializer.ANNOTATION))
-                    || typeof(Guid).IsAssignableFrom(type))
+                    || typeof(Guid).IsAssignableFrom(type)
+                    || typeof(Nullable<Guid>).IsAssignableFrom(type))
                 {
                     var serializer = this.GetPrimitiveSerializer<Guid>(new IonGuidSerializer(this.options));
                     return serializer.Deserialize(reader);


### PR DESCRIPTION
*Issue #, if available:*
68

*Description of changes:*
Previously, `IonByteArraySerializer` is used to deserialize Ion blobs to Nullable<Guid>. This PR enables the IonSerializer to use the `IonGuidSerializer` in that scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
