### PR TITLE
Add IonClobAttribute

### DIFF
--- a/Amazon.IonObjectMapper.Test/IonClobTest.cs
+++ b/Amazon.IonObjectMapper.Test/IonClobTest.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.IonObjectMapper.Demo
+{
+    using System.IO;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static Amazon.IonObjectMapper.Test.Utils;
+
+    public class Club
+    {
+        [IonClob(encoding = "Unicode")]
+        public string name { get; set; } = "homeschool club";
+
+        public string address { get; set; } = "street corner";
+    }
+
+    [TestClass]
+    public class IonClobTest
+    {
+        [TestMethod]    
+        public void Scratch()
+        {
+            IonSerializer ionSerializer;
+            MemoryStream stream;
+            Club result;
+
+            Club club = new Club();
+
+            ionSerializer = new IonSerializer();
+            stream = (MemoryStream)ionSerializer.Serialize(club);
+            result = ionSerializer.Deserialize<Club>(stream);
+            Check(result.name, "homeschool club");
+            Check(result.address, "street corner");
+        }
+    }
+}

--- a/Amazon.IonObjectMapper.Test/Utils.cs
+++ b/Amazon.IonObjectMapper.Test/Utils.cs
@@ -37,7 +37,7 @@ namespace Amazon.IonObjectMapper.Test
         {
             var stream = new MemoryStream();
             var writer = IonTextWriterBuilder.Build(new StreamWriter(stream));
-            writer.WriteClob(Encoding.ASCII.GetBytes(clob));
+            writer.WriteClob(Encoding.Unicode.GetBytes(clob));
             writer.Flush();
             writer.Finish();
             stream.Position = 0;

--- a/Amazon.IonObjectMapper/Attribute/IonClobAttribute.cs
+++ b/Amazon.IonObjectMapper/Attribute/IonClobAttribute.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.IonObjectMapper
+{
+    using System;
+
+    /// <summary>
+    /// Attribute to identify an Ion Clob 
+    /// that can be applied to the string type
+    /// </summary>
+    public class IonClobAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the encoding to be used with the Ion Clob.
+        /// </summary>
+        public string encoding { get; set; }
+    }
+}

--- a/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/IonObjectSerializer.cs
@@ -269,6 +269,14 @@ namespace Amazon.IonObjectMapper
                     writer.AddTypeAnnotation(this.options.AnnotationConvention.Apply(this.options, ionAnnotateType, propertyType));
                 }
 
+                var ionClob = (IonClobAttribute)Attribute.GetCustomAttribute(property, typeof(IonClobAttribute), false);
+                if (ionClob != null)
+                {
+                    var serializer = new IonClobSerializer(ionClob.encoding);
+                    serializer.Serialize(writer, propertyValue as string);
+                    continue;
+                }
+
                 this.ionSerializer.Serialize(writer, propertyValue);
                 serializedIonFields.Add(ionPropertyName);
             }

--- a/Amazon.IonObjectMapper/Serializer/Primitive/IonClobSerializer.cs
+++ b/Amazon.IonObjectMapper/Serializer/Primitive/IonClobSerializer.cs
@@ -13,6 +13,7 @@
 
 namespace Amazon.IonObjectMapper
 {
+    using System;
     using System.Text;
     using Amazon.IonDotnet;
 
@@ -21,6 +22,31 @@ namespace Amazon.IonObjectMapper
     /// </summary>
     public class IonClobSerializer : IonSerializer<string>
     {
+        private readonly Encoding encoding;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IonGuidSerializer"/> class.
+        /// </summary>
+        ///
+        /// <param name="encoding">Type of encoding for Clob.</param>
+        public IonClobSerializer(string encodingString = "Unicode")
+        {
+            switch (encodingString)
+            {
+                case "Unicode":
+                    this.encoding = Encoding.Unicode;
+                    break;
+                case "ASCII":
+                    this.encoding = Encoding.ASCII;
+                    break;
+                case "UTF-8":
+                    this.encoding = Encoding.UTF8;
+                    break;
+                default:
+                    throw new Exception("Not a valid encoding");
+            }
+        }
+
         /// <summary>
         /// Deserialize CLOB value.
         /// </summary>
@@ -32,7 +58,7 @@ namespace Amazon.IonObjectMapper
         {
             byte[] clob = new byte[reader.GetLobByteSize()];
             reader.GetBytes(clob);
-            return Encoding.UTF8.GetString(clob);
+            return this.encoding.GetString(clob);
         }
 
         /// <summary>
@@ -43,7 +69,7 @@ namespace Amazon.IonObjectMapper
         /// <param name="item">The CLOB value to serialize.</param>
         public override void Serialize(IIonWriter writer, string item)
         {
-            writer.WriteClob(Encoding.UTF8.GetBytes(item));
+            writer.WriteClob(this.encoding.GetBytes(item));
         }
     }
 }

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -198,3 +198,18 @@ public class Car
 }
 ```
 
+
+#### IonClob
+
+Strings can be tagged with this attribute to use a different encoding scheme in the Ion Clob type.
+
+```c#
+public class Car
+{
+    [IonClob(encoding = "Unicode")]
+    private string color;
+
+    [IonClob(encoding = "UTF-8")]
+    private string manufacturer;
+}
+```


### PR DESCRIPTION
*Issue #, if available:*
[73](https://github.com/amzn/ion-object-mapper-dotnet/issues/73)

*Description of changes:*
Add IonClobAttribute which takes an encoding so customers can specify which string properties should be converted to an Ion Clob instead of an Ion String.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
