### PR TITLE
Upgrade to .NET Standard 2.1/.NET 6

### DIFF
--- a/Amazon.IonObjectMapper.Demo/Amazon.IonObjectMapper.Demo.csproj
+++ b/Amazon.IonObjectMapper.Demo/Amazon.IonObjectMapper.Demo.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
+++ b/Amazon.IonObjectMapper.PerformanceTest/Amazon.IonObjectMapper.PerformanceTest.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
+++ b/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <LangVersion>latestMajor</LangVersion>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>1.0.0</Version>


### PR DESCRIPTION
*Issue #, if available:* Upgrade to .NET Standard 2.1/.NET 6

*Description of changes:*
I'd like to use this project, but .NET Core 3.1 is end-of-life. This PR moves the base project to .NET Standard 2.1, and upgrades the `Demo`, `Test`, and `PerformanceTest` projects to .NET 6.

Both the `Test` and `PerformanceTest` tests pass as they did before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
