### PR TITLE
Upgraded Amazon.IonDotnet reference version to 1.2.2

### DIFF
--- a/Amazon.IonObjectMapper.Demo/Amazon.IonObjectMapper.Demo.csproj
+++ b/Amazon.IonObjectMapper.Demo/Amazon.IonObjectMapper.Demo.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.2.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
+++ b/Amazon.IonObjectMapper.Test/Amazon.IonObjectMapper.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.2.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
+++ b/Amazon.IonObjectMapper/Amazon.IonObjectMapper.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change updates the reference of Amazon.IonDotnet to version 1.2.2, in order to match the version referenced by the package awslabs/amazon-qldb-driver-dotnet. This update fixes compatibility issues for projects that need to use both awslabs/amazon-qldb-driver-dotnet and ion-object-mapper-dotnet.

Without this update some functionality within this package is unavailable when a project also references the awslabs/amazon-qldb-driver-dotnet package. This is due to ion-object-mapper-dotnet expecting interfaces from the 1.1.0 version of the Amazon.IonDotnet library, not the 1.2.2 version that awslabs/amazon-qldb-driver-dotnet references.

**Example**
Project References:
```
<PackageReference Include="Amazon.QLDB.Driver" Version="1.4.1" />
<PackageReference Include="Amazon.QLDB.Driver.Serialization" Version="1.0.0" />
```
Code:
```
IIonReader reader = IonReaderBuilder.Build(ionValueObject);
IonSerializer ionSerializer = new IonSerializer();
var deserializedObject = ionSerializer.Deserialize<MyType>(reader);
```

Error: 

>   Program.cs(24, 26): [CS0012] The type 'IIonReader' is defined in an assembly that is not referenced. You must add a reference to assembly 'Amazon.IonDotnet, Version=1.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604'.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.